### PR TITLE
Add LLVM build to CI

### DIFF
--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-source /Marlin/.travis-ci.d/init_x86_64.sh
+ILCSOFT=/cvmfs/clicdp.cern.ch/iLCSoft/builds/current/CI_${COMPILER}
+source $ILCSOFT/init_ilcsoft.sh
 
-cd /Marlin
+cd /Package
 mkdir build
 cd build
 cmake -GNinja -C $ILCSOFT/ILCSoft.cmake ..

--- a/.travis-ci.d/init_x86_64.sh
+++ b/.travis-ci.d/init_x86_64.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-#--------------------------------------------------------------------------------
-#     ILCSOFT
-#--------------------------------------------------------------------------------
-
-ILCSOFT=/cvmfs/clicdp.cern.ch/iLCSoft/builds/current/CI_gcc
-source $ILCSOFT/init_ilcsoft.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,26 @@ dist: trusty
 services:
   - docker
 
+language: cpp
+
+env:
+  matrix:
+    - COMPILER=gcc
+    - COMPILER=llvm
+
 # command to install dependencies
 install:
   - shopt -s extglob dotglob
-  - mkdir Marlin
-  - mv !(Marlin) Marlin
+  - mkdir Package
+  - mv !(Package) Package
   - shopt -u dotglob
-  - export PKGDIR=${PWD}/Marlin
-  - cat $PKGDIR/.travis-ci.d/compile_and_test.sh
+  - export PKGDIR=${PWD}/Package
   - curl -O https://lcd-data.web.cern.ch/lcd-data/CernVM/cernvm3-docker-latest.tar
   - cat cernvm3-docker-latest.tar | docker import - cernvm
 
 # command to run tests
 script:
-  - docker run -t -v $PKGDIR:/Marlin cernvm /init /Marlin/.travis-ci.d/compile_and_test.sh
+  - docker run -t -v $PKGDIR:/Package -e COMPILER=$COMPILER cernvm /init /Package/.travis-ci.d/compile_and_test.sh
 
 # Don't send e-mail notifications
 notifications:


### PR DESCRIPTION
Now two builds are started on Travis one with gcc 6.2 and one with LLVM 3.9.

The two files:
- .travis-ci.d/compile_and_test.sh 
- .travis.yml 
are so generic now that they can be added without modification to any iLCSoft package.