### PR TITLE
ProcessorMgr: enable checking of conditions for eventModifiers

### DIFF
--- a/source/src/ProcessorMgr.cc
+++ b/source/src/ProcessorMgr.cc
@@ -374,7 +374,11 @@ namespace marlin{
       Global::EVENTSEEDER->refreshSeeds( evt ) ;
 
       for( ProcessorList::iterator it = _eventModifierList.begin();  it !=  _eventModifierList.end()  ; ++ it) {
-      
+
+        if( not( _conditions.conditionIsTrue( (*it)->name() ) )) {
+          continue;
+        }
+
         streamlog::logscope scope( streamlog::out ) ; scope.setName(  (*it)->name()  ) ;
 	
 	scope.setLevel( (*it)->logLevelName() ) ;


### PR DESCRIPTION

BEGINRELEASENOTES
- Add possibility to use conditions also for eventModify processors. The processor setting the conditions must also run under modifyEvent!

ENDRELEASENOTES