### PR TITLE
EventSeeder: use vector of pairs to fix order of seeding processors

### DIFF
--- a/source/include/marlin/ProcessorEventSeeder.h
+++ b/source/include/marlin/ProcessorEventSeeder.h
@@ -3,6 +3,7 @@
 
 #include "lcio.h"
 #include "EVENT/LCEvent.h"
+#include <vector>
 #include <map>
 
 using namespace lcio ;
@@ -96,9 +97,9 @@ namespace marlin{
      */
     bool _eventProcessingStarted ;
 
-    /** Map to hold pointers to the registered processors and their assigned seeds
+    /** vector to hold pair of pointers to the registered processors and their assigned seeds
      */
-    std::map<Processor*, unsigned int> _seed_map ;
+    std::vector< std::pair<Processor*, unsigned int> > _vector_pair_proc_seed;
 
   } ;
 


### PR DESCRIPTION
The loop over the map is not guaranteed to be constant across time or space so event seeds were not reproducible, because the order of the pointer to the processors depends on the memory.

Now use a vector with fixed order from processors calling to register themselves, which is constant.

BEGINRELEASENOTES
- EventSeeder: make event seed truly constant in space and time

ENDRELEASENOTES