### PR TITLE
Marlin parameter ownership cleanup

### DIFF
--- a/source/include/marlin/CCProcessor.h
+++ b/source/include/marlin/CCProcessor.h
@@ -41,7 +41,7 @@ namespace marlin {
   public:
 
     // Constructor
-    CCProcessor( bool status, const std::string& name, const std::string& type, StringParameters* p=NULL);
+    CCProcessor( bool status, const std::string& name, const std::string& type, std::shared_ptr<StringParameters> p);
 
     // Copy Constructor
     CCProcessor( CCProcessor &p );
@@ -100,7 +100,7 @@ namespace marlin {
     bool isParamOptional( const std::string& key );
     
     /** Returns the string parameters for this processor */
-    StringParameters* getParameters(){ return _param; }
+    std::shared_ptr<StringParameters> getParameters(){ return _param; }
     
     /** Returns a map with collection names and their respective types for INPUT/OUTPUT collections of this processor */
     const ssMap& getColHeaders( const std::string& iotype ){ return _types[iotype]; }
@@ -153,7 +153,7 @@ namespace marlin {
     ///////////////////////////////////////////////////////////////////////////////
     // METHODS
     ///////////////////////////////////////////////////////////////////////////////
-    void addColsFromParam( StringParameters* p );
+    void addColsFromParam( std::shared_ptr<StringParameters> p );
     void writeColsToParam();
     void clearParameters();
     void setMarlinProc();	    //sets error flag NOT_INSTALLED if processor couldn't be set
@@ -166,7 +166,7 @@ namespace marlin {
     std::vector<bool> _error;	    // 0 = proc has no parameters; 1 = proc is not build in this marlin installation; 2 = unavailable collections
     std::string _name;		    // name of the processor
     std::string _type;		    // type of the processor
-    StringParameters* _param;	    // parameters from processor
+    std::shared_ptr<StringParameters> _param;	    // parameters from processor
     Processor* _proc;		    // associated Marlin processor
  
     const StringVec _error_desc{ "Processor has no Parameters", "Processor not available!", "Some Collections have Errors"}; // error descriptions for all processors

--- a/source/include/marlin/CMProcessor.h
+++ b/source/include/marlin/CMProcessor.h
@@ -8,7 +8,7 @@ namespace marlin{
     typedef std::set< std::string > sSet;
     typedef std::map< std::string, bool > sbMap;
     typedef std::map< std::string, std::string > ssMap;
-    typedef std::map< std::string, StringParameters* > sSPMap;
+    typedef std::map< std::string, std::shared_ptr<StringParameters> > sSPMap;
     
  /**
  * This singleton class contains an instance
@@ -34,11 +34,11 @@ namespace marlin{
 	ssMap getProcDesc(){ return _mpDescriptions; }
 
 	/** returns the parameters for the processor of the given type */
-	StringParameters* getSParams( const std::string& type );
+        std::shared_ptr<StringParameters> getSParams( const std::string& type );
 	
 	/** merges the given parameters with the default ones 
 	 *  from the processor with the given type */
-	StringParameters* mergeParams( const std::string& type, StringParameters* sp );
+	std::shared_ptr<StringParameters> mergeParams( const std::string& type, std::shared_ptr<StringParameters> sp );
 	
 	/** returns the parameter with the given key
 	 *  of the processor with the given type */

--- a/source/include/marlin/IParser.h
+++ b/source/include/marlin/IParser.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 
 namespace marlin{
 
@@ -28,7 +29,7 @@ namespace marlin{
     virtual void setCmdLineParameters( const CommandLineParametersMap & cmdlineparams ) = 0 ;
 
     /** Return the StringParameters defined for this section of the steering file */
-    virtual StringParameters* getParameters( const std::string& sectionName ) const =0 ;
+    virtual std::shared_ptr<StringParameters> getParameters( const std::string& sectionName ) const =0 ;
     
   };
 

--- a/source/include/marlin/MarlinSteerCheck.h
+++ b/source/include/marlin/MarlinSteerCheck.h
@@ -107,7 +107,7 @@ namespace marlin {
     sSet& getColsSet( const std::string& type, const std::string& name, CCProcessor* proc );
 
     /** Returns the Global Parameters */
-    StringParameters* getGlobalParameters(){ return _gparam; }
+    std::shared_ptr<StringParameters> getGlobalParameters(){ return _gparam; }
     
     /** Writes the collection errors for the active processor with given index to the given stream */
     void dumpColErrors( unsigned int i, std::ostream& stream, bool separators=false );
@@ -122,7 +122,7 @@ namespace marlin {
     void changeLCIOFilePos( unsigned int pos, unsigned int newPos );
  
     /** Add a new processor */
-    void addProcessor( bool status, const std::string& name, const std::string& type, StringParameters* p=NULL );
+    void addProcessor( bool status, const std::string& name, const std::string& type, std::shared_ptr<StringParameters> p );
 
     /** Remove processor with the given status at the given index */
     void remProcessor( unsigned int index, bool status );
@@ -217,7 +217,7 @@ namespace marlin {
 					//Warning: Some Inactive Processors are not installed
 
     IParser* _parser;			//parser
-    StringParameters* _gparam;		//global parameters (without LCIO Files)
+    std::shared_ptr<StringParameters> _gparam;		//global parameters (without LCIO Files)
     
     std::string _steeringFile;		//steering file name + path as passed by the user in the command line
     std::string _XMLFileName="";	//steering file name

--- a/source/include/marlin/Parser.h
+++ b/source/include/marlin/Parser.h
@@ -15,7 +15,7 @@ namespace marlin{
 class LCTokenizer ;
 
 
-typedef std::map< std::string ,  StringParameters* > StringParametersMap ;
+typedef std::map< std::string ,  std::shared_ptr<StringParameters> > StringParametersMap;
 
 
 /** Simple parser class for Marlin.
@@ -45,7 +45,7 @@ public:
   Parser( const std::string& fileName ) ;
   virtual ~Parser() ; 
 
-  StringParameters* getParameters( const std::string& sectionName ) const ;
+  std::shared_ptr<StringParameters> getParameters( const std::string& sectionName ) const ;
 
     /** set command line parameters */
     void setCmdLineParameters( const CommandLineParametersMap &  ){

--- a/source/include/marlin/Processor.h
+++ b/source/include/marlin/Processor.h
@@ -21,6 +21,7 @@
 #include "streamlog/streamlog.h"
 
 #include <map>
+#include <memory>
 
 // ----- define some useful macros-----------
 // for backward compatibility - use streamlog_out( MESSAGE )  instead 
@@ -137,7 +138,7 @@ namespace marlin{
 
     /** Return parameters defined for this Processor.
      */
-    virtual StringParameters* parameters() { return _parameters ; } 
+    virtual std::shared_ptr<StringParameters> parameters() { return _parameters ; }
 
 
     /** Print information about this processor in ASCII steering file format.
@@ -402,7 +403,7 @@ namespace marlin{
   private: // called by ProcessorMgr
     
     /** Allow friend class CCProcessor to change/reset processor parameters */
-    virtual void setProcessorParameters( StringParameters* parameters) {
+    virtual void setProcessorParameters( std::shared_ptr<StringParameters> parameters) {
 	setParameters( parameters ) ;
     }
     
@@ -413,7 +414,7 @@ namespace marlin{
     virtual void setName( const std::string & name) { _processorName = name ; }
     
     /** Initialize the parameters */
-    virtual void setParameters( StringParameters* parameters) ; 
+    virtual void setParameters( std::shared_ptr<StringParameters> parameters) ;
     
     /** Sets the registered steering parameters before calling init() 
      */
@@ -451,7 +452,7 @@ namespace marlin{
     std::string _description="";
     std::string _typeName="";
     std::string _processorName="";
-    StringParameters* _parameters=NULL;
+    std::shared_ptr<StringParameters> _parameters{};
 
     ProcParamMap _map{};
     bool _isFirstEvent = false;

--- a/source/include/marlin/ProcessorMgr.h
+++ b/source/include/marlin/ProcessorMgr.h
@@ -59,7 +59,7 @@ public:
    *  of active processors including a condition for the execution of the processEvent() method.
    */
   bool addActiveProcessor( const std::string& processorType , const std::string& processorName ,
-			   StringParameters* parameters , const std::string condition="true" ) ;
+			   std::shared_ptr<StringParameters> parameters , const std::string condition="true" ) ;
   
   /** Remove processor with name from list of active processors.
    */

--- a/source/include/marlin/XMLParser.h
+++ b/source/include/marlin/XMLParser.h
@@ -3,17 +3,19 @@
 
 #include "IParser.h"
 #include "StringParameters.h"
+#include "marlin/tinyxml.h"
 
 #include <fstream>
 #include <string>
 #include <iostream>
+#include <memory>
 
 class TiXmlNode ;
 class TiXmlDocument ;
 
 namespace marlin{
 
-  typedef std::map< std::string , StringParameters* > StringParametersMap ;
+  typedef std::map< std::string , std::shared_ptr<StringParameters> > StringParametersMap;
 
   /** XML parser for Marlin steering files.
    *  Marlin XML steering files have the following form (use <b>Marlin -x > example.xml</b> to 
@@ -157,7 +159,7 @@ namespace marlin{
     void parse() ;
 
     /** Return the StringParameters for the section as read from the xml file */
-    StringParameters* getParameters( const std::string& sectionName ) const ;
+    std::shared_ptr<StringParameters> getParameters( const std::string& sectionName ) const ;
   
 
   protected:
@@ -186,7 +188,7 @@ namespace marlin{
 
     mutable StringParametersMap _map{};
     StringParameters* _current ;
-    TiXmlDocument* _doc ;
+    std::unique_ptr<TiXmlDocument> _doc{};
 
     std::string _fileName ;
 

--- a/source/src/CCProcessor.cc
+++ b/source/src/CCProcessor.cc
@@ -8,7 +8,7 @@ using namespace std;
 namespace marlin{
 
   //constructor
-  CCProcessor::CCProcessor( bool status, const string& name, const string& type, StringParameters* p ):
+  CCProcessor::CCProcessor( bool status, const string& name, const string& type, std::shared_ptr<StringParameters> p ):
     _status(status),
     _error(MAX_ERRORS, false),
     _name(name),
@@ -66,7 +66,7 @@ namespace marlin{
 
       if( p._param != NULL ){
 	p.writeColsToParam();
-	_param=new StringParameters( *p._param );
+	_param= std::make_shared<StringParameters>( *p._param );
 	addColsFromParam( _param );
 	p.clearParameters();
         clearParameters();
@@ -74,10 +74,6 @@ namespace marlin{
   }
  
   CCProcessor::~CCProcessor(){
-      if( _param != NULL){
-	  delete _param;
-	  _param=NULL;
-      }
       for( ssColVecMap::const_iterator q=_cols.begin(); q!=_cols.end(); q++ ){
 	 if( q->first != UNAVAILABLE && q->first != DUPLICATE ){
 	    for( sColVecMap::const_iterator r=q->second.begin(); r!=q->second.end(); r++ ){
@@ -89,7 +85,7 @@ namespace marlin{
       }
   }
 
-  void CCProcessor::addColsFromParam( StringParameters* p ){
+  void CCProcessor::addColsFromParam( std::shared_ptr<StringParameters> p ){
     if( p == NULL ){
 	setError( NO_PARAMETERS );
 	return;

--- a/source/src/CMProcessor.cc
+++ b/source/src/CMProcessor.cc
@@ -36,7 +36,7 @@ namespace marlin{
 		_mpDescriptions[ (*p) ] = pp->description();
 
 		//create new string parameters for each processor
-		_mpSParameters[ (*p) ] = new StringParameters;
+		_mpSParameters[ (*p) ] = std::make_shared<StringParameters>();
 
 		//set the parameters keys
 		_mProcs[ (*p) ]->setProcessorParameters( _mpSParameters[ (*p) ] );
@@ -96,14 +96,14 @@ namespace marlin{
 	return NULL;
     }
     
-    StringParameters* CMProcessor::getSParams( const string& type ){
+    std::shared_ptr<StringParameters> CMProcessor::getSParams( const string& type ){
 	if( isInstalled( type )){
 	    return _mpSParameters[ type ];
 	}
 	return NULL;
     }
     
-    StringParameters* CMProcessor::mergeParams( const string& type, StringParameters* sp ){
+    std::shared_ptr<StringParameters> CMProcessor::mergeParams( const string& type, std::shared_ptr<StringParameters> sp ){
 	if( isInstalled( type )){
 	    if( sp ){
 		StringVec keys;
@@ -140,7 +140,7 @@ namespace marlin{
 	    }
 	    //if processor is installed and no parameters were passed (from the xml file)
 	    //create a copy from the default parameters for this processor and return it
-	    StringParameters *defaultSP= new StringParameters( *_mpSParameters[ type ] );
+	    std::shared_ptr<StringParameters> defaultSP= std::make_shared<StringParameters>( *(_mpSParameters[ type ].get()) );
 
 	    return defaultSP;
 	}

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -289,7 +289,7 @@ int main(int argc, char** argv ){
 
     parser->parse() ;
 
-    Global::parameters = parser->getParameters("Global")  ;
+    Global::parameters = parser->getParameters("Global").get();
 
     //fg: can't use assert, as this generates no code when compiled with NDEBUG
     if( Global::parameters  == 0 ) {
@@ -588,7 +588,7 @@ void createProcessors( const IParser&  parser) {
     //     for( StringVec::iterator m = activeProcessors.begin() ; m != activeProcessors.end() ; m++){
     for(unsigned int i=0 ; i<  activeProcessors.size() ; i++ ) {
 
-        StringParameters* p = parser.getParameters( activeProcessors[i] )  ;
+        std::shared_ptr<StringParameters> p = parser.getParameters( activeProcessors[i] );
 
         if( p!=0 ){
             std::string type = p->getStringVal("ProcessorType") ;
@@ -615,8 +615,8 @@ void  createProcessors(Parser&  parser) {
     //for( StringVec::iterator m = activeProcessors.begin() ; m != activeProcessors.end() ; m++){
     for(unsigned int i=0 ; i<  activeProcessors.size() ; i++ ) {
 
-        //StringParameters* p = parser.getParameters( *m )  ;
-        StringParameters* p = parser.getParameters( activeProcessors[i] )  ;
+        //std::shared_ptr<StringParameters> p = parser.getParameters( *m )  ;
+        std::shared_ptr<StringParameters> p = parser.getParameters( activeProcessors[i] );
 
 
         streamlog_out( MESSAGE ) << " Parameters for processor " << activeProcessors[i]

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -32,7 +32,7 @@
 
 #include <cstring>
 #include <algorithm>
-
+#include <memory>
 
 #include "gearimpl/Util.h"
 #include "gearxml/GearXML.h"
@@ -268,7 +268,7 @@ int main(int argc, char** argv ){
 
 
 
-    IParser* parser ;
+    std::unique_ptr<IParser> parser;
 
     // for now allow xml and old steering
     std::string filen(  steeringFileName ) ;
@@ -276,11 +276,11 @@ int main(int argc, char** argv ){
     if( filen.rfind(".xml") == std::string::npos ||  // .xml not found at all
             !(  filen.rfind(".xml")
                 + strlen(".xml") == filen.length() ) ) {  
-        parser = new Parser( steeringFileName ) ;
+        parser = std::unique_ptr<IParser> ( new Parser( steeringFileName ) );
 
     } else {
 
-        parser = new XMLParser( steeringFileName ) ;
+        parser = std::unique_ptr<IParser>( new XMLParser(steeringFileName) ) ;
 
         // tell parser to take into account any options defined on the command line
         parser->setCmdLineParameters( cmdlineparams ) ;

--- a/source/src/MarlinSteerCheck.cc
+++ b/source/src/MarlinSteerCheck.cc
@@ -41,7 +41,7 @@ namespace marlin{
 
     //create Global Parameters
     else{
-	_gparam = new StringParameters;
+        _gparam = std::make_shared<StringParameters>();
 	StringVec value;
 	value.push_back("5001");
 	_gparam->add("MaxRecordNumber", value);
@@ -115,10 +115,6 @@ namespace marlin{
 	delete _parser;
 	_parser=NULL;
     }
-    if(_gparam){
-	delete _gparam;
-	_gparam=NULL;
-    }
   }
 
   // Returns a list of all available Collections of a given Type
@@ -133,7 +129,7 @@ namespace marlin{
 	v = findMatchingCols( getAllCols(), proc, type );
 	for( unsigned int i=0; i<v.size(); i++ ){
 	    //check if collection already exists
-	    CCProcessor tmp(ACTIVE, "Temporary", "Temporary");
+	    CCProcessor tmp(ACTIVE, "Temporary", "Temporary", std::shared_ptr<StringParameters>());
 	    if( findMatchingCols( proc->getCols( INPUT ), &tmp, type, v[i]->getValue(), name ).size() == 0 ){
 		_colValues.insert( v[i]->getValue() );
 	    }
@@ -154,7 +150,7 @@ namespace marlin{
 	}
 	
 	//create temporary processor to find matching collections
-	CCProcessor tmp(ACTIVE, "Temporary", "Temporary");
+	CCProcessor tmp(ACTIVE, "Temporary", "Temporary", std::shared_ptr<StringParameters>());
 	
 	for( unsigned int i=0; i<v.size(); i++ ){
 	    if( v[i]->getType() == type ){
@@ -238,7 +234,7 @@ namespace marlin{
 	  LCCollection* col = evt->getCollection( *name ) ;
 	 
 	  //check if collection already exists
-	  CCProcessor tmp(ACTIVE, "Temporary", "Temporary");
+	  CCProcessor tmp(ACTIVE, "Temporary", "Temporary", std::shared_ptr<StringParameters>());
 	  if( findMatchingCols(newCols, &tmp, col->getTypeName(), *name).size() == 0 ){
 	      //store the LCIO Filename in the unused name variable from the processor parameters
 	      CCCollection* newCol = new CCCollection( *name, col->getTypeName(), file);
@@ -325,7 +321,7 @@ namespace marlin{
   }
 
   // Add a new Processor
-  void MarlinSteerCheck::addProcessor( bool status, const string& name, const string& type, StringParameters* p ){
+  void MarlinSteerCheck::addProcessor( bool status, const string& name, const string& type, std::shared_ptr<StringParameters> p ){
 
     CCProcessor* newProc = new CCProcessor(status, name, type, p);
    
@@ -538,7 +534,7 @@ namespace marlin{
       cerr << "parseXMLFile: Failed to load file: " << e.what() << endl;
       return false;
     }
-      _gparam = _parser->getParameters( "Global" );
+    _gparam = _parser->getParameters( "Global" );
       
       //============================================================
       //READ PARAMETERS
@@ -621,7 +617,7 @@ namespace marlin{
       for( unsigned int i=0; i<availableProcs.size(); i++ ){
 	    
 	//get StringParameters from xml file for the name of the Processor
-	StringParameters* p = _parser->getParameters( availableProcs[i] );
+	std::shared_ptr<StringParameters> p = _parser->getParameters( availableProcs[i] );
 	    
 	//get type of processor from the parameters
 	string type = p->getStringVal( "ProcessorType" );
@@ -645,7 +641,7 @@ namespace marlin{
 	//if processor has no parameters set the type to "Undefined!!"
 	if( !found ){
 	  //add the processor to the active processors
-	  addProcessor( ACTIVE, activeProcs[i], "Undefined!!");
+	  addProcessor( ACTIVE, activeProcs[i], "Undefined!!",  std::shared_ptr<StringParameters>() );
 	  _errors.insert("Some Processors have no parameters");
 	}
       }

--- a/source/src/Parser.cc
+++ b/source/src/Parser.cc
@@ -51,8 +51,8 @@ namespace marlin{
 	  std::cerr << " Parser::parse : section has to have a name: .begin sectionName " << std::endl ;
 	  exit(1) ;
 	}
-	_current = new StringParameters() ;
-	_map[ tokens[1] ] = _current ;
+	_map[ tokens[1] ] = std::make_shared<StringParameters>();
+	_current = _map[ tokens[1] ].get() ;
 	//       std::cout << " Parser::parse: >>> creating new map entry : " <<  tokens[1] << std::endl ;
 
       } else if (  tokens[0] == ".end"   ) {
@@ -87,7 +87,7 @@ namespace marlin{
 
       std::string name = iter->first ; 
 
-      StringParameters* p = iter->second ;
+      StringParameters* p = iter->second.get() ;
 
       std::string type = p->getStringVal("ProcessorType") ;
 
@@ -110,7 +110,7 @@ namespace marlin{
   }
 
 
-  StringParameters* Parser::getParameters( const std::string& sectionName ) const {
+  std::shared_ptr<StringParameters> Parser::getParameters( const std::string& sectionName ) const {
 
     for( StringParametersMap::const_iterator iter = _map.begin() ; iter != _map.end() ; iter++){
       //     std::cout << " parameter section " << iter->first 

--- a/source/src/Processor.cc
+++ b/source/src/Processor.cc
@@ -35,10 +35,6 @@ namespace marlin{
 
   Processor::~Processor() {
 
-    if( _parameters != 0 ){
-      delete _parameters ;
-    }
-
     if( _str !=0 )
       delete _str ;
   
@@ -55,12 +51,8 @@ namespace marlin{
   }
 
 
-  void Processor::setParameters( StringParameters* parameters) {
+  void Processor::setParameters( std::shared_ptr<StringParameters> parameters) {
 
-    if( _parameters != 0 ){
-      delete _parameters ;
-      _parameters = 0 ;
-    }
     _parameters = parameters ;
 
     updateParameters();
@@ -233,7 +225,7 @@ namespace marlin{
 
     for( PMI i = _map.begin() ; i != _map.end() ; i ++ ) {
 
-      i->second->setValue( _parameters ) ;
+      i->second->setValue( _parameters.get() ) ;
     }
   }
 

--- a/source/src/ProcessorMgr.cc
+++ b/source/src/ProcessorMgr.cc
@@ -68,8 +68,6 @@ namespace marlin{
   
   
   ProcessorMgr::~ProcessorMgr(){
-    delete Global::EVENTSEEDER ;
-    Global::EVENTSEEDER = NULL ;
   }
 
     void ProcessorMgr::registerProcessor( Processor* processor ){
@@ -219,7 +217,7 @@ namespace marlin{
 
     bool ProcessorMgr::addActiveProcessor( const std::string& processorType , 
             const std::string& processorName , 
-            StringParameters* parameters ,
+            std::shared_ptr<StringParameters> parameters ,
             const std::string condition) {
 
         Processor* processor = getProcessor( processorType ) ;
@@ -612,7 +610,18 @@ namespace marlin{
 
         streamlog_out(MESSAGE) << " --------------------------------------------------------- "  << std::endl ;
 
+        //delete _me;
+        //_me = nullptr;
+
+
+        delete Global::EVENTSEEDER ;
+        Global::EVENTSEEDER = nullptr ;
+
+        for (auto& pair : _activeMap ) {
+          delete pair.second;
+        }
     }
+
   
 
     } // namespace marlin

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -15,7 +15,7 @@ namespace marlin{
 
     // open steering file with processor names 
     XMLParser::XMLParser( const std::string&  fileName, bool forCCheck ) :
-        _current(NULL) , _doc(NULL), _fileName( fileName ), _forCCheck( forCCheck ) {
+        _current(NULL) , _fileName( fileName ), _forCCheck( forCCheck ) {
         }
 
     XMLParser::~XMLParser(){
@@ -24,7 +24,7 @@ namespace marlin{
     void XMLParser::parse(){
 
 
-        _doc = new TiXmlDocument ;
+        _doc = std::unique_ptr<TiXmlDocument>( new TiXmlDocument );
         bool loadOkay = _doc->LoadFile(_fileName  ) ;
 
         if( !loadOkay ) {
@@ -50,13 +50,13 @@ namespace marlin{
         TiXmlNode* section = 0 ;
 
 
-        StringParameters*  globalParameters = new StringParameters() ;
-        _map[ "Global" ] = globalParameters ;
+        _map[ "Global" ] = std::make_shared<StringParameters>();
+        StringParameters*  globalParameters = _map[ "Global" ].get();
 
         section = root->FirstChild("global")  ;
 
         if( section != 0  ){
-            _current =  _map[ "Global" ] ;
+            _current =  _map[ "Global" ].get() ;
             parametersFromNode( section ) ;
 
         }  else {
@@ -172,10 +172,9 @@ namespace marlin{
 
             // std::cout << " processor found: " << section->Value() << std::endl ;
 
-            _current = new StringParameters() ;
-
             std::string name( getAttribute( section, "name") ) ;
-            _map[ name  ] =  _current ;
+            _map[ name  ] = std::make_shared<StringParameters>();
+            _current = _map[ name  ].get();
 
             // exit if processor defined more than once in the execute section
             if( procList.find( name ) != procList.end() ){
@@ -442,7 +441,7 @@ namespace marlin{
     //   TiXmlElement* child2 = docHandle.FirstChild( "Document" ).FirstChild( "Element" ).Child( "Child", 1 ).Element();
     //   if ( child2 ){}
 
-    StringParameters* XMLParser::getParameters( const std::string& sectionName ) const {
+    std::shared_ptr<StringParameters> XMLParser::getParameters( const std::string& sectionName ) const {
 
         //     for( StringParametersMap::iterator iter = _map.begin() ; iter != _map.end() ; iter++){
         //       //     std::cout << " parameter section " << iter->first 


### PR DESCRIPTION

BEGINRELEASENOTES
- XMLParser: cleanup member objects, make StringParameters shared pointers to simplify ownership
   Previously some were owned by the Processors, others were still owned by the XMLParser object
   adapted interfaces
- Processors: functions using `StringParameter*` now use or return `shared_ptr<StringParameters>` instead

ENDRELEASENOTES