### PR TITLE
adapt MarlinGUi to shared_ptr<StringParameters>

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -14,21 +14,6 @@
   - Fix warnings for clang
   - ignore warnings from external headers
 
-# v01-11
-
-* 2017-02-27 Andre Sailer ([PR#8](https://github.com/iLCSoft/Marlin/pull/8))
-  - Fix warnings for GCC
-  - moved tinyXML to separate library
-
-* 2016-12-07 Marko Petric ([PR#6](https://github.com/iLCSoft/Marlin/pull/6))
-  - Made CI configuration generic and usable for all packages without modifications
-
-* 2016-12-07 Andre Sailer ([PR#4](https://github.com/iLCSoft/Marlin/pull/4))
-  - Add travis configuration to repository, enable testing for PRs
-
-* 2016-11-25 Frank Gaede ([PR#3](https://github.com/iLCSoft/Marlin/pull/3))
-  - Fix warnings for clang
-  - ignore warnings from external headers
 
 # v01-10
 

--- a/source/gui/addprocdialog.cpp
+++ b/source/gui/addprocdialog.cpp
@@ -4,6 +4,7 @@
 
 #include "marlin/MarlinSteerCheck.h"
 #include "marlin/CMProcessor.h"
+#include <memory>
 
 using namespace std;
 
@@ -108,7 +109,7 @@ void APDialog::addProcessor(){
 
     if( !existsProc ){
 	//add new processor
-	_msc->addProcessor( ACTIVE, le->displayText().toStdString(), cb->currentText().toStdString() );
+      _msc->addProcessor( ACTIVE, le->displayText().toStdString(), cb->currentText().toStdString() , std::shared_ptr<StringParameters>() );
 	
 	//edit processor
 	emit( editProcessor( (int)_msc->getAProcs().size()-1 ));

--- a/source/gui/mainwindow.cpp
+++ b/source/gui/mainwindow.cpp
@@ -602,7 +602,7 @@ void MainWindow::setMarlinSteerCheck( const char* filename )
     updateConds();
 
     //Delegate
-    GParamDelegate *gpDelegate = new GParamDelegate( msc->getGlobalParameters(), this, globalSectionTable );
+    GParamDelegate *gpDelegate = new GParamDelegate( msc->getGlobalParameters().get() , this, globalSectionTable );
     globalSectionTable->setItemDelegate( gpDelegate );
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- adapt MarlinGUi to new usage of shared_ptr<StringParameters>
 - remove duplicate entry in ReleaseNotes.md 

ENDRELEASENOTES