### PR TITLE
Include feature

### DIFF
--- a/source/include/marlin/XMLParser.h
+++ b/source/include/marlin/XMLParser.h
@@ -185,6 +185,10 @@ namespace marlin{
      */
     void processconditions( TiXmlNode* current , const std::string& conditions ) ;
 
+    /** Helper method - recursively replace all <include ref="..."> with the corresponding 
+     *  file content
+     */
+    void processIncludeElements( TiXmlElement* element );
 
     mutable StringParametersMap _map{};
     StringParameters* _current ;
@@ -210,4 +214,3 @@ namespace marlin{
  * where name and type are required attibutes.
  * 
  */
- 


### PR DESCRIPTION
BEGINRELEASENOTES
- Added <include> element feature to read external xml file and replace in main Marlin steering file
- Added an include mechanism to the `XMLParser` class, allowing to load xml files into the main Marlin steering file. Note that :
  - Nested includes will not be processed in the current version (include of include does not work)
   - Exceptions are thrown if something goes wrong with the xml element (wrong name, no file, etc ...)
   - Includes are processed iteratively in the document inside the root element.


ENDRELEASENOTES