### PR TITLE
Using constants in XML files

### DIFF
--- a/source/include/marlin/XMLParser.h
+++ b/source/include/marlin/XMLParser.h
@@ -166,7 +166,7 @@ namespace marlin{
 
     /** Extracts all parameters from the given node and adss them to the current StringParameters object
      */
-    void parametersFromNode(TiXmlNode* section, std::pair<unsigned,unsigned>* typeCount=0) ;
+    void parametersFromNode(TiXmlNode* section, std::map<std::string, std::string>& constants, std::pair<unsigned,unsigned>* typeCount=0) ;
 
     /** Return named attribute - throws ParseException if attribute doesn't exist */
     const char* getAttribute( TiXmlNode* node , const std::string& name ) ;
@@ -189,6 +189,10 @@ namespace marlin{
      *  file content
      */
     void processIncludeElements( TiXmlElement* element );
+
+    void processConstants( TiXmlNode* node , std::map<std::string, std::string>& constants ) ;
+    
+    std::string &performConstantReplacement( std::string& value, std::map<std::string, std::string>& constants ) ;
 
     mutable StringParametersMap _map{};
     StringParameters* _current ;

--- a/source/include/marlin/XMLParser.h
+++ b/source/include/marlin/XMLParser.h
@@ -188,11 +188,14 @@ namespace marlin{
     /** Helper method - recursively replace all <include ref="..."> with the corresponding 
      *  file content
      */
-    void processIncludeElements( TiXmlElement* element );
+    void processIncludeElements( TiXmlElement* element , const std::map<std::string, std::string>& constants );
+    
+    void processIncludeElement( TiXmlElement* element , const std::map<std::string, std::string>& constants , TiXmlDocument &document);
 
     void processConstants( TiXmlNode* node , std::map<std::string, std::string>& constants ) ;
+    void processConstant( TiXmlElement* element , std::map<std::string, std::string>& constants ) ;
     
-    std::string &performConstantReplacement( std::string& value, std::map<std::string, std::string>& constants ) ;
+    std::string &performConstantReplacement( std::string& value, const std::map<std::string, std::string>& constants ) ;
 
     mutable StringParametersMap _map{};
     StringParameters* _current ;

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -167,7 +167,8 @@ int main(int argc, char** argv ){
             // save dynamic options into map
             cmdlineparams[ cmdlinekey[0] ][ cmdlinekey[1] ] = cmdlinearg[1] ;
 
-            cout << "<!-- steering file parameter: [ " << cmdlinekey[0] << "." << cmdlinekey[1] << " ] will be OVERWRITTEN with value: [\"" << cmdlinearg[1] << "\"] -->" << endl;
+            std::string type = cmdlinekey[0] == "constant" ? "constant" : "parameter" ;
+            cout << "<!-- steering file " << type << ": [ " << cmdlinekey[0] << "." << cmdlinekey[1] << " ] will be OVERWRITTEN with value: [\"" << cmdlinearg[1] << "\"] -->" << endl;
 
             // erase dynamic options from **argv
             for( int j = i ; j < argc-1 ; j++ ){

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -727,7 +727,9 @@ namespace marlin{
             
             if( replacementValue.empty() ) {
               
-                std::cout << "XMLParser::performConstantReplacement : constant \"" << key << "\" not found in available constants !" << std::endl ; 
+                std::stringstream str ;
+                str << "XMLParser::performConstantReplacement : constant \"" << key << "\" not found in available constants !" ;
+                throw ParseException( str.str() ) ;
             }
             
             value.replace( pos , (pos2+1-pos) , replacementValue ) ;

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -589,19 +589,19 @@ namespace marlin{
 
         std::string ref ( element->Attribute("ref") ) ;
 
+        try { performConstantReplacement( ref, constants ) ;                  
+        }
+        catch( ParseException & e ) {
+            std::cout << "XMLParser::processIncludeElement : Couldn't parse include ref \"" << ref << "\"" << std::endl ;
+            throw e ;
+        }
+        
         if( ref.size() < 5 || ref.substr( ref.size() - 4 ) != ".xml" ) {
           
             std::stringstream str ;
             str  << "XMLParser::processIncludeElement invalid ref file name \"" << ref
                 << "\" in element <" << element->Value() << "/> in file " << _fileName  ;
             throw ParseException( str.str() ) ;
-        }
-        
-        try { performConstantReplacement( ref, constants ) ;                  
-        }
-        catch( ParseException & e ) {
-            std::cout << "XMLParser::processIncludeElement : Couldn't parse include ref \"" << ref << "\"" << std::endl ;
-            throw e ;
         }
 
         std::cout << "Ref = " << ref << std::endl ;

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -46,9 +46,7 @@ namespace marlin{
             throw ParseException(std::string( "XMLParser::parse : no root tag <marlin>...</marlin> found in  ") 
                     + _fileName  ) ;
         }
-
-        processIncludeElements( root ) ;
-
+        
         TiXmlNode* section = 0 ;
         
         section = root->FirstChild("constants") ;
@@ -59,6 +57,8 @@ namespace marlin{
         } else {
           std::cout << "XMLParser::parse : no <constants/> section found in " << _fileName << std::endl ;
         }
+
+        processIncludeElements( root ) ;
 
         _map[ "Global" ] = std::make_shared<StringParameters>();
         StringParameters*  globalParameters = _map[ "Global" ].get();

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -361,8 +361,9 @@ namespace marlin{
             try {
                 performConstantReplacement( inputLine , constants );
             }
-            catch(ParseException) {
-                
+            catch(ParseException &e) {
+              std::cout << "XMLParser::parse : Couldn't parse parameter \"" << name << "\"" << std::endl ;
+              throw e ;
             }
             
 
@@ -604,7 +605,6 @@ namespace marlin{
             throw ParseException( str.str() ) ;
         }
 
-        std::cout << "Ref = " << ref << std::endl ;
         std::string refFileName ;
 
         if( ref.at(0) != '/' ) {
@@ -653,8 +653,6 @@ namespace marlin{
             // constants may be defined in includes and could then be
             // used in next constant values
             else if ( std::string( child->Value() ) == "include" ) {
-              
-                std::cout << "Found an include element in constants section" << std::endl;
                 
                 // process the include and returns the first and last elements found in the include
                 TiXmlDocument document ;
@@ -768,7 +766,8 @@ namespace marlin{
     
     std::string &XMLParser::performConstantReplacement( std::string& value, const std::map<std::string, std::string>& constants ) {
         
-        size_t pos = value.find_first_of("${") ;
+        size_t pos = value.find("${") ;
+        std::string original(value);
         
         while( pos != std::string::npos ) {
           
@@ -793,7 +792,7 @@ namespace marlin{
             value.replace( pos , (pos2+1-pos) , replacementValue ) ;
             pos2 = pos + replacementValue.size() ; // new end position after replace
             
-            pos = value.find_first_of("${") ; // find next possible key to replace
+            pos = value.find("${", pos2) ; // find next possible key to replace
         }
         
         return value ;

--- a/test/testmarlin/CMakeLists.txt
+++ b/test/testmarlin/CMakeLists.txt
@@ -42,6 +42,21 @@ SET_TESTS_PROPERTIES( t_processoreventseeder PROPERTIES FAIL_REGULAR_EXPRESSION 
 
 SET_TESTS_PROPERTIES( t_processoreventseeder PROPERTIES PASS_REGULAR_EXPRESSION ". ERROR .TestProcessorEventSeeder.. ProcessorEventSeeder:registerProcessor" )
 
+#---------------------------------------------------------------------------------------
+SET( MARLIN_STEERING_FILE base-eventmodifier.xml )
+
+SET( MARLIN_INPUT_FILES 
+  ${CMAKE_CURRENT_SOURCE_DIR}/${MARLIN_STEERING_FILE}
+  ${CMAKE_CURRENT_SOURCE_DIR}/gear_simjob.xml
+  ${CMAKE_CURRENT_SOURCE_DIR}/simjob.slcio
+  ${CMAKE_CURRENT_SOURCE_DIR}/include-eventmodifier.xml
+  ${CMAKE_CURRENT_SOURCE_DIR}/constants-eventmodifier.xml
+)
+CONFIGURE_FILE( runmarlin.cmake.in includeandconstants.cmake @ONLY ) 
+
+ADD_TEST( t_includeandconstants "${CMAKE_COMMAND}" -P includeandconstants.cmake )
+SET_TESTS_PROPERTIES( t_includeandconstants PROPERTIES PASS_REGULAR_EXPRESSION "TestEventModifier modified 3 events in 1 run" )
+
 # the order of the match printed out on failure seems to go from last to first. So using the first of the two SET_TESTS_PROPERTIES below is more useful when trying to see when a specified test failed, in this case the test containing" Seeds don't match".  
 #SET_TESTS_PROPERTIES( t_processoreventseeder PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR .TestProcessorEventSeeder.;ERROR .TestProcessorEventSeeder.* Seeds don't match" )
 #SET_TESTS_PROPERTIES( t_processoreventseeder PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR .TestProcessorEventSeeder.* Seeds don't match;ERROR .TestProcessorEventSeeder."   )

--- a/test/testmarlin/base-eventmodifier.xml
+++ b/test/testmarlin/base-eventmodifier.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="us-ascii"?>
+
+<marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
+  
+  <constants>
+    <constant name="constantFile" value="constants-eventmodifier.xml"/>
+    <include ref="${constantFile}" />
+  </constants>
+ <execute>
+  <processor name="MyTestEventModifier"/>
+ </execute>
+
+ <global>
+  <parameter name="LCIOInputFiles"> ${lcioFile} </parameter>
+  <parameter name="MaxRecordNumber" value="4" />  
+  <parameter name="GearXMLFile"> gear_simjob.xml </parameter>  
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE3 DEBUG </parameter> 
+ </global>
+
+ <include ref="${includefile}"/>
+
+</marlin>

--- a/test/testmarlin/constants-eventmodifier.xml
+++ b/test/testmarlin/constants-eventmodifier.xml
@@ -1,0 +1,2 @@
+<constant name="includefile" value="include-eventmodifier.xml" />
+<constant name="lcioFile" value="simjob.slcio" />

--- a/test/testmarlin/include-eventmodifier.xml
+++ b/test/testmarlin/include-eventmodifier.xml
@@ -1,0 +1,3 @@
+ <processor name="MyTestEventModifier" type="TestEventModifier">
+ </processor>
+


### PR DESCRIPTION
BEGINRELEASENOTES
- Added a constants section in XMLParser parsing : 
   - Allows to write constants and refer to in processor parameter values and global parameter values
   - Makes use of ${constantName} to refer to a constant
   - Use command line argument to override a constant
   - example:
```xml
  <constants>
    <constant name="MCParticleCollection" value="MCParticle"/>
    <constant name="FilePath" value="../../test/testmarlin"/>
    <constant name="InputFile" value="${FilePath}/simjob.slcio"/>
  </constants>
```
```shell
Marlin --constant.InputFile=aDifferentFile.slcio  marlin.xml
```
ENDRELEASENOTES

This has been tested with the test processor in the examples/mymarlin directory as for #19 .
Test it with this file : [marlin.txt](https://github.com/iLCSoft/Marlin/files/1329207/marlin.txt) (rename it with .xml extension)

```shell
# from Marlin root dir :
cd examples/mymarlin/
mkdir build
cd build
cmake -C $ILCSOFT/ILCSoft.cmake .. && make install
cd ..
Marlin marlin.xml
```

