### PR TITLE
Dump post processed XML file

### DIFF
--- a/source/include/marlin/IParser.h
+++ b/source/include/marlin/IParser.h
@@ -31,6 +31,9 @@ namespace marlin{
     /** Return the StringParameters defined for this section of the steering file */
     virtual std::shared_ptr<StringParameters> getParameters( const std::string& sectionName ) const =0 ;
     
+    /** Write down the parsed file in a new file */
+    virtual void write(const std::string& fname) const =0 ;
+    
   };
 
 }

--- a/source/include/marlin/Parser.h
+++ b/source/include/marlin/Parser.h
@@ -56,6 +56,9 @@ public:
   /** Parse the input file
    */
   void parse() ;
+  
+  /** Write down the parsed file in a new file. For this implementation, just copy paste the steering file */
+  void write(const std::string& fname) const ;
 
 
 protected:

--- a/source/include/marlin/XMLParser.h
+++ b/source/include/marlin/XMLParser.h
@@ -160,8 +160,9 @@ namespace marlin{
 
     /** Return the StringParameters for the section as read from the xml file */
     std::shared_ptr<StringParameters> getParameters( const std::string& sectionName ) const ;
-  
-
+    
+    /** Write the parsed XML tree in an other file */
+    void write(const std::string &filen) const ;
   protected:
 
     /** Extracts all parameters from the given node and adss them to the current StringParameters object

--- a/source/include/marlin/XMLParser.h
+++ b/source/include/marlin/XMLParser.h
@@ -197,6 +197,8 @@ namespace marlin{
     void processConstant( TiXmlElement* element , std::map<std::string, std::string>& constants ) ;
     
     std::string &performConstantReplacement( std::string& value, const std::map<std::string, std::string>& constants ) ;
+    
+    void checkForNestedIncludes( const TiXmlNode *node );
 
     mutable StringParametersMap _map{};
     StringParameters* _current ;

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -247,17 +247,23 @@ int main(int argc, char** argv ){
                 return(1);
             }
         }
-        else if( std::string(argv[1]) == "-p" ){
+        else if( std::string(argv[1]) == "-p" || std::string(argv[1]) == "-n" ){
           if( argc == 4 ){
-            std::unique_ptr<XMLParser> parser = std::unique_ptr<XMLParser>( new XMLParser(argv[2]) ) ;
+            std::unique_ptr<XMLParser> parser = std::unique_ptr<XMLParser>( new XMLParser(argv[3]) ) ;
             // tell parser to take into account any options defined on the command line
             parser->setCmdLineParameters( cmdlineparams ) ;
             parser->parse();
-            parser->write( argv[3] );
-            return(0);
+            parser->write( argv[2] );
+            
+            // option -p : write and exit
+            if( std::string(argv[1]) == "-n" )
+              return(0);
+            // option -n : write and steering file for further processing
+            else
+              steeringFileName = argv[3] ;
           }
           else{
-              std::cout << "  usage: Marlin -p steering.xml poststeering.xml" << std::endl << std::endl;
+              std::cout << "  usage: Marlin " << argv[1] << " poststeering.xml steering.xml" << std::endl << std::endl;
               return(1);
           }
         }
@@ -265,10 +271,10 @@ int main(int argc, char** argv ){
 
             return printUsage() ;
         }
-
-
-        // one argument given: the steering file for normal running :
-        steeringFileName = argv[1] ;
+        else{
+            // one argument given: the steering file for normal running :
+            steeringFileName = argv[1] ;          
+        }
 
     } else {
 

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -247,6 +247,20 @@ int main(int argc, char** argv ){
                 return(1);
             }
         }
+        else if( std::string(argv[1]) == "-p" ){
+          if( argc == 4 ){
+            std::unique_ptr<XMLParser> parser = std::unique_ptr<XMLParser>( new XMLParser(argv[2]) ) ;
+            // tell parser to take into account any options defined on the command line
+            parser->setCmdLineParameters( cmdlineparams ) ;
+            parser->parse();
+            parser->write( argv[3] );
+            return(0);
+          }
+          else{
+              std::cout << "  usage: Marlin -p steering.xml poststeering.xml" << std::endl << std::endl;
+              return(1);
+          }
+        }
         else if( std::string(argv[1]) == "-h"  || std::string(argv[1]) == "-?" ){
 
             return printUsage() ;

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -251,11 +251,12 @@ int main(int argc, char** argv ){
         }
         else if( std::string(argv[1]) == "-n" ){
           if( argc == 3 ){
-            dryRun = true;
+            dryRun = true ;
+            steeringFileName = argv[2] ;
           }
           else{
-              std::cout << "  usage: Marlin " << argv[1] << " steering.xml" << std::endl << std::endl;
-              return(1);
+              std::cout << "  usage: Marlin " << argv[1] << " steering.xml" << std::endl << std::endl ;
+              return(1) ;
           }
         }
         else if( std::string(argv[1]) == "-h"  || std::string(argv[1]) == "-?" ){
@@ -311,14 +312,14 @@ int main(int argc, char** argv ){
         return(1) ;
     }
 
-    std::string parsedFileName = Global::parameters->getStringVal( "ParsedFileName" ) ;
+    std::string outputSteeringFile = Global::parameters->getStringVal( "OutputSteeringFile" ) ;
     
-    if( parsedFileName.size() > 0 ){
-      parser->write( parsedFileName ) ;
+    if( outputSteeringFile.size() > 0 ){
+      parser->write( outputSteeringFile ) ;
     }
     
     if( dryRun ){
-      std::cout << "Marlin in dry-run mode. Exiting ..." << std::endl ;
+      std::cout << "Marlin running in dry-run mode (-n option). Exiting ..." << std::endl ;
       return(0) ;
     }
 

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -180,6 +180,8 @@ int main(int argc, char** argv ){
     }
 
     cout << endl ;
+    
+    bool dryRun(false);
 
     // read file name from command line
     if( argc > 1 ){
@@ -247,23 +249,12 @@ int main(int argc, char** argv ){
                 return(1);
             }
         }
-        else if( std::string(argv[1]) == "-p" || std::string(argv[1]) == "-n" ){
-          if( argc == 4 ){
-            std::unique_ptr<XMLParser> parser = std::unique_ptr<XMLParser>( new XMLParser(argv[3]) ) ;
-            // tell parser to take into account any options defined on the command line
-            parser->setCmdLineParameters( cmdlineparams ) ;
-            parser->parse();
-            parser->write( argv[2] );
-            
-            // option -p : write and exit
-            if( std::string(argv[1]) == "-n" )
-              return(0);
-            // option -n : write and steering file for further processing
-            else
-              steeringFileName = argv[3] ;
+        else if( std::string(argv[1]) == "-n" ){
+          if( argc == 3 ){
+            dryRun = true;
           }
           else{
-              std::cout << "  usage: Marlin " << argv[1] << " poststeering.xml steering.xml" << std::endl << std::endl;
+              std::cout << "  usage: Marlin " << argv[1] << " steering.xml" << std::endl << std::endl;
               return(1);
           }
         }
@@ -320,6 +311,16 @@ int main(int argc, char** argv ){
         return(1) ;
     }
 
+    std::string parsedFileName = Global::parameters->getStringVal( "ParsedFileName" ) ;
+    
+    if( parsedFileName.size() > 0 ){
+      parser->write( parsedFileName ) ;
+    }
+    
+    if( dryRun ){
+      std::cout << "Marlin in dry-run mode. Exiting ..." << std::endl ;
+      return(0) ;
+    }
 
     // //-----  register log level names with the logstream ---------
     streamlog::out.addLevelName<DEBUG>() ;

--- a/source/src/Parser.cc
+++ b/source/src/Parser.cc
@@ -157,6 +157,29 @@ namespace marlin{
 
     return 0 ;
   }
+  
+  
+  
+  void Parser::write(const std::string& fname) const{
+    std::ifstream inFile( _fileName.c_str()  ) ;
+    
+    if( ! inFile ){
+      std::cerr << "Parser::write:  couldn't open input file: " << _fileName  << std::endl ;
+      return ;
+    }
+    
+    std::ofstream outFile( fname.c_str()  ) ;
+    
+    if( ! outFile ){
+      std::cerr << "Parser::write:  couldn't open output file: " << fname  << std::endl ;
+      return ;
+    }
+    
+    outFile << inFile.rdbuf() ;
+    inFile.close() ;
+    outFile.close() ;
+  } 
+  
 
 
 

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -655,7 +655,26 @@ namespace marlin{
             throw ParseException( str.str() ) ;
 
         }
+        
+        checkForNestedIncludes( &document ) ;
     
+    }
+    
+    
+    void XMLParser::checkForNestedIncludes( const TiXmlNode *node ){
+        
+        for(const TiXmlElement *child = node->FirstChildElement() ; child ; child = child->NextSiblingElement()){
+          
+          if( child->Value() == std::string("include") ) {
+            std::stringstream ss;
+            ss << "Nested includes are not allowed [in file: " << node->GetDocument()->Value() << ", line: " << child->Row() << "] !" ;
+            throw ParseException( ss.str() ) ;            
+          }
+          
+          checkForNestedIncludes( child ) ;
+
+        }
+        
     }
 
 

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -366,13 +366,7 @@ namespace marlin{
                     inputLine =  par->FirstChild()->Value() ;
             }
             
-            try {
-                performConstantReplacement( inputLine , constants );
-            }
-            catch(ParseException &e) {
-              std::cout << "XMLParser::parse : Couldn't parse parameter \"" << name << "\"" << std::endl ;
-              throw e ;
-            }
+
             
 
             
@@ -410,6 +404,7 @@ namespace marlin{
 	      }
 	    }
       
+      // replace the pre-processed parameter value in the xml tree 
       try{  
         getAttribute( par , "value" ) ;
         if( par->ToElement() )
@@ -419,6 +414,15 @@ namespace marlin{
 
           if( par->FirstChild() )
               par->FirstChild()->SetValue( inputLine ) ;
+      }
+      
+      // evaluate constant value
+      try {
+          performConstantReplacement( inputLine , constants );
+      }
+      catch(ParseException &e) {
+        std::cout << "XMLParser::parse : Couldn't parse parameter \"" << name << "\"" << std::endl ;
+        throw e ;
       }
 
             // std::cout << " values : " << inputLine << std::endl ;
@@ -802,8 +806,19 @@ namespace marlin{
                 }
             }
         }
-
         
+        // replace the pre-processed constant in the XML element
+        if( element->Attribute("value") ) {
+          
+            element->SetAttribute("value", value) ;
+        }
+        else {
+
+            if( element->FirstChild() )
+                element->FirstChild()->SetValue(value) ;
+        }
+
+        // evaluate constant value
         try { performConstantReplacement( value, constants ) ;                  
         }
         catch( ParseException & e ) {
@@ -815,17 +830,6 @@ namespace marlin{
             std::stringstream str ;
             str << "XMLParser::processConstant : couldn't add constant \"" << name << "\" to constant map !" << std::endl ;
             throw ParseException( str.str() ) ;
-        }
-        
-        // replace the processed constant in the XML element
-        if( element->Attribute("value") ) {
-          
-            element->SetAttribute("value", value) ;
-        }
-        else {
-
-            if( element->FirstChild() )
-                element->FirstChild()->SetValue(value) ;
         }
         
         std::cout << "Read constant \"" << name << "\" , value = \"" << value << "\"" << std::endl ;

--- a/test/testmarlin/base-eventmodifier.xml
+++ b/test/testmarlin/base-eventmodifier.xml
@@ -15,6 +15,7 @@
   <parameter name="MaxRecordNumber" value="4" />  
   <parameter name="GearXMLFile"> gear_simjob.xml </parameter>  
   <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE3 DEBUG </parameter> 
+  <parameter name="OutputSteeringFile"> base-eventmodifier-parsed.xml </parameter>
  </global>
 
  <include ref="${includefile}"/>


### PR DESCRIPTION
BEGINRELEASENOTES
- Added write() method to XMLParser (resp. Parser) to write the loaded xml tree (resp. same file) in a new file.
- Many methods adapted in XMLParser to make parameter/constant replacements persistent in the XML tree
- New global parameter "OutputSteeringFile" introduced to write down a new steering file after processing
- Added command line option -n for a Marlin dry-run
- Example : 
```shell
# take the output file name from steering file and run Marlin as usual
Marlin steeringFile.xml 
# same but exit after writing the output steering file
Marlin -n steeringFile.xml 
# change the output file name
Marlin steeringFile.xml --global.OutputSteeringFile=MyParsedSteeringFile.xml 
```

ENDRELEASENOTES