### PR TITLE
Conditions with constants

### DIFF
--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -116,6 +116,8 @@ namespace marlin{
                 activeProcs.push_back( procName ) ;
 
                 std::string condition(  getAttribute( proc,"condition")  ) ;
+                 
+                performConstantReplacement( condition, constants ) ;
 
                 if( condition.size() == 0 ) 
                     condition += "true" ;


### PR DESCRIPTION

BEGINRELEASENOTES
- Added constants replacement for condition attributes in the execute section
  - Allows permanent conditions at runtime (not depending on processor return values)
  - Allows to refer to constants in conditions in the execute section, e.g : 
```xml
<constants>
  <constant name="RunOverlay" value="false" />
</constants>

<execute>
  <if condition="${RunOverlay}">
    <processor name="MyOverlayBg"/>
  </if>
</execute>
```
and run : 
```shell
Marlin steering.xml --constant.RunOverlay=true
```
to change the behavior.
ENDRELEASENOTES