### PR TITLE
Removed "hard" exception in ProcessorMgr::processRunHeader() 

### DIFF
--- a/source/src/ProcessorMgr.cc
+++ b/source/src/ProcessorMgr.cc
@@ -319,18 +319,23 @@ namespace marlin{
 
         if( doConsistencyCheck  && lcioDetName != gearDetName ) {
 
-            std::stringstream sstr ;
-
-            sstr  << std::endl
-                << " ============================================================= " << std::endl
-                << " ProcessorMgr::processRunHeader : inconsistent detector models : " << std::endl 
-                << " in lcio : " << lcioDetName << " <=> in gear file : "  << gearDetName << std::endl
-                << " ============================================================= " << std::endl
-                << std::endl ;
+            // std::stringstream sstr ;
+            // 
+            // sstr  << std::endl
+            //     << " ============================================================= " << std::endl
+            //     << " ProcessorMgr::processRunHeader : inconsistent detector models : " << std::endl 
+            //     << " in lcio : " << lcioDetName << " <=> in gear file : "  << gearDetName << std::endl
+            //     << " ============================================================= " << std::endl
+            //     << std::endl ;
 
             //throw lcio::Exception( sstr.str() )  ;
 
-            throw ProcMgrStopProcessing( sstr.str() ) ;
+            // throw ProcMgrStopProcessing( sstr.str() ) ;
+            
+            streamlog_out(WARNING) << " ============================================================= " << std::endl ;
+            streamlog_out(WARNING) << " ProcessorMgr::processRunHeader : inconsistent detector models : " << std::endl ;
+            streamlog_out(WARNING) << " in lcio : " << lcioDetName << " <=> in gear file : "  << gearDetName << std::endl ;
+            streamlog_out(WARNING) << " ============================================================= " << std::endl ;
         }
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- remove exception thrown in ProcessorMgr::processRunHeader() if gear detector name is different from the one in the lcio file, and just warn the user

ENDRELEASENOTES