### PR TITLE
Processors with Constants

### DIFF
--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -120,7 +120,8 @@ namespace marlin{
             while( ( proc = section->IterateChildren( "processor", proc ) )  != 0  ){
 
                 std::string procName( getAttribute( proc, "name") );
-                
+                performConstantReplacement( procName, constants ) ;
+
                 //std::cout << "looping over processor " + procName << std::endl;
 
                 // exit if processor defined more than once in the execute section


### PR DESCRIPTION
BEGINRELEASENOTES
- XMLParsing: Replace constants in processor names: allows switching at initialisation time, e.g.:
```
<processor name="BeamCalReco${BCReco}"/>
```
   and `Marlin --constant.BCReco=350GeV` to chose which BeamCalReco processor to run

ENDRELEASENOTES