### PR TITLE
Fixwarn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ DISPLAY_STD_VARIABLES()
 
 
 # generate and install following configuration files
-GENERATE_PACKAGE_CONFIGURATION_FILES( MarlinConfig.cmake MarlinConfigVersion.cmake MarlinLibDeps.cmake )
+GENERATE_PACKAGE_CONFIGURATION_FILES( MarlinConfig.cmake MarlinConfigVersion.cmake )
 
 
 

--- a/examples/mymarlin/include/MyProcessor.h
+++ b/examples/mymarlin/include/MyProcessor.h
@@ -62,10 +62,10 @@ class MyProcessor : public Processor {
 
   /** Input collection name.
    */
-  std::string _colName ;
+  std::string _colName{} ;
 
-  int _nRun ;
-  int _nEvt ;
+  int _nRun{} ;
+  int _nEvt{} ;
 } ;
 
 #endif

--- a/source/gui/addcondition.h
+++ b/source/gui/addcondition.h
@@ -23,6 +23,8 @@ class ACDialog : public QDialog
     Q_OBJECT
 
 public:
+    ACDialog(const ACDialog&) = default;
+    ACDialog& operator=(const ACDialog&) = default;
     ACDialog(MarlinSteerCheck* msc, QWidget *parent = 0, Qt::WFlags f = 0);
 
 signals:
@@ -33,11 +35,11 @@ private slots:
 
 private:
     //Variables
-    QMainWindow* _parent;
-    QLineEdit *le;
-    QVBoxLayout *mainLayout; 
+    QMainWindow* _parent{};
+    QLineEdit *le{};
+    QVBoxLayout *mainLayout{}; 
     
-    MarlinSteerCheck* _msc;
+    MarlinSteerCheck* _msc{};
 };
 
 #endif

--- a/source/gui/addprocdialog.h
+++ b/source/gui/addprocdialog.h
@@ -25,7 +25,9 @@ class APDialog : public QDialog
 {
     Q_OBJECT
 
-public:
+ public:
+    APDialog(const APDialog&) = default ;
+    APDialog& operator=(const APDialog&) = default ;
     APDialog(MarlinSteerCheck* msc, QWidget *parent = 0, Qt::WFlags f = 0);
 
 signals:
@@ -40,14 +42,14 @@ private slots:
 
 private:
     //Variables
-    ssMap procTypes;
-    QMainWindow* _parent;
-    QComboBox *cb;
-    QLabel *procLabel;
-    QLineEdit *le;
-    QVBoxLayout *mainLayout; 
+    ssMap procTypes{};
+    QMainWindow* _parent{};
+    QComboBox *cb{};
+    QLabel *procLabel{};
+    QLineEdit *le{};
+    QVBoxLayout *mainLayout{}; 
     
-    MarlinSteerCheck* _msc;
+    MarlinSteerCheck* _msc{};
 };
 
 #endif

--- a/source/gui/aprocdelegate.h
+++ b/source/gui/aprocdelegate.h
@@ -15,6 +15,9 @@ class AProcDelegate : public QItemDelegate
     Q_OBJECT
 
 public:
+    AProcDelegate(const AProcDelegate&) = default ;
+    AProcDelegate& operator=(const AProcDelegate&) = default ;
+
     AProcDelegate(QObject *parent = 0);
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -22,7 +25,7 @@ public:
     void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 
 private:
-    QObject* _parent;
+  QObject* _parent{};
 };
 
 #endif

--- a/source/gui/dialog.h
+++ b/source/gui/dialog.h
@@ -23,6 +23,8 @@ class Dialog : public QDialog
     Q_OBJECT
 
 public:
+    Dialog(const Dialog&) = default ;
+    Dialog& operator=(const Dialog&) = default ;
     Dialog(CCProcessor* p, MarlinSteerCheck* msc, QWidget *parent = 0, Qt::WFlags f = 0);
 
 public slots:
@@ -37,12 +39,12 @@ private:
     void setupViews();
     
     //variables
-    QVBoxLayout *mainLayout;
-    QTableWidget *paramTable;
-    QTableWidget *optParamTable;
+    QVBoxLayout *mainLayout{};
+    QTableWidget *paramTable{};
+    QTableWidget *optParamTable{};
     
-    CCProcessor* _p;
-    MarlinSteerCheck* _msc;
+    CCProcessor* _p{};
+    MarlinSteerCheck* _msc{};
 };
 
 #endif

--- a/source/gui/editcondition.h
+++ b/source/gui/editcondition.h
@@ -23,6 +23,8 @@ class ECDialog : public QDialog
     Q_OBJECT
 
 public:
+    ECDialog(const ECDialog&) = default ;
+    ECDialog& operator=(const ECDialog&) = default ;
     ECDialog(MarlinSteerCheck* msc, const std::string& oldCond, QWidget *parent = 0, Qt::WFlags f = 0);
 
 signals:
@@ -33,12 +35,12 @@ private slots:
 
 private:
     //Variables
-    QMainWindow* _parent;
-    QLineEdit *le;
-    QVBoxLayout *mainLayout; 
+    QMainWindow* _parent{};
+    QLineEdit *le{};
+    QVBoxLayout *mainLayout{}; 
     
-    MarlinSteerCheck* _msc;
-    std::string _oldCond;
+    MarlinSteerCheck* _msc{};
+    std::string _oldCond{};
 };
 
 #endif

--- a/source/gui/flowlayout.h
+++ b/source/gui/flowlayout.h
@@ -49,7 +49,7 @@ public:
 private:
     int doLayout(const QRect &rect, bool testOnly) const;
 
-    QList<QLayoutItem *> itemList;
+    QList<QLayoutItem *> itemList{};
 };
 
 #endif

--- a/source/gui/gparamdelegate.h
+++ b/source/gui/gparamdelegate.h
@@ -22,6 +22,8 @@ class GParamDelegate : public QItemDelegate
     Q_OBJECT
 
 public:
+    GParamDelegate(const GParamDelegate&) = default ;
+    GParamDelegate& operator=(const GParamDelegate&) = default ;
     GParamDelegate(StringParameters* p, QMainWindow* mw, QObject *parent = 0);
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -29,9 +31,9 @@ public:
     void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 
 private:
-    StringParameters* _p;
-    QMainWindow* _mw;
-    QTableWidget* _parent;
+    StringParameters* _p{};
+    QMainWindow* _mw{};
+    QTableWidget* _parent{};
 };
 
 #endif

--- a/source/gui/guihelp.h
+++ b/source/gui/guihelp.h
@@ -18,10 +18,12 @@ class GUIHelp : public QWidget
     Q_OBJECT
 
 public:
+    GUIHelp(const GUIHelp&) = default ;
+    GUIHelp& operator=(const GUIHelp&) = default ;
     GUIHelp(QString path="/gui/help/index.html", QWidget* parent=0, Qt::WFlags f=0 );
     
 private:
-    QTextBrowser *browser;
+    QTextBrowser *browser{};
 };
 
 #endif

--- a/source/gui/icoldelegate.cpp
+++ b/source/gui/icoldelegate.cpp
@@ -42,7 +42,7 @@ void IColDelegate::setEditorData(QWidget *editor, const QModelIndex &index) cons
     }
     else{
 	comboBox->addItem(index.model()->data(index).toString());
-	int pos = comboBox->findText(index.model()->data(index).toString(), Qt::MatchExactly);
+	pos = comboBox->findText(index.model()->data(index).toString(), Qt::MatchExactly);
 	comboBox->setCurrentIndex(pos);
     }
     if( _p->isActive() ){

--- a/source/gui/icoldelegate.h
+++ b/source/gui/icoldelegate.h
@@ -22,6 +22,8 @@ class IColDelegate : public QItemDelegate
     Q_OBJECT
 
 public:
+    IColDelegate(const IColDelegate&) = default ;
+    IColDelegate& operator=(const IColDelegate&) = default ;
     IColDelegate(CCProcessor* p, MarlinSteerCheck* msc, const QString& name, const QString& type, QObject *parent = 0);
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -33,11 +35,11 @@ public slots:
     void remCollection();
 
 private:
-    std::string _name;
-    std::string _type;
-    CCProcessor* _p;
-    MarlinSteerCheck* _msc;
-    QTableWidget* _parent;
+    std::string _name{};
+    std::string _type{};
+    CCProcessor* _p{};
+    MarlinSteerCheck* _msc{};
+    QTableWidget* _parent{};
 };
 
 #endif

--- a/source/gui/icoltdelegate.cpp
+++ b/source/gui/icoltdelegate.cpp
@@ -52,7 +52,7 @@ void IColTDelegate::setEditorData(QWidget *editor, const QModelIndex &index) con
 	}
 	else{
 	    comboBox->addItem(index.model()->data(index).toString());
-	    int pos = comboBox->findText(index.model()->data(index).toString(), Qt::MatchExactly);
+	    pos = comboBox->findText(index.model()->data(index).toString(), Qt::MatchExactly);
 	    comboBox->setCurrentIndex(pos);
 	}
 	

--- a/source/gui/icoltdelegate.h
+++ b/source/gui/icoltdelegate.h
@@ -22,6 +22,8 @@ class IColTDelegate : public QItemDelegate
     Q_OBJECT
 
 public:
+    IColTDelegate(const IColTDelegate&) = default ;
+    IColTDelegate& operator=(const IColTDelegate&) = default ;
     IColTDelegate(CCProcessor* p, MarlinSteerCheck* msc, QObject *parent = 0);
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -29,9 +31,9 @@ public:
     void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 
 private:
-    CCProcessor* _p;
-    MarlinSteerCheck* _msc;
-    QTableWidget* _parent;
+    CCProcessor* _p{};
+    MarlinSteerCheck* _msc{};
+    QTableWidget* _parent{};
 };
 
 #endif

--- a/source/gui/iprocdelegate.h
+++ b/source/gui/iprocdelegate.h
@@ -15,6 +15,8 @@ class IProcDelegate : public QItemDelegate
     Q_OBJECT
 
 public:
+    IProcDelegate(const IProcDelegate&) = default ;
+    IProcDelegate& operator=(const IProcDelegate&) = default ;
     IProcDelegate(QObject *parent = 0);
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -22,7 +24,7 @@ public:
     void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 
 private:
-    QObject* _parent;
+    QObject* _parent{};
 };
 
 #endif

--- a/source/gui/mainwindow.h
+++ b/source/gui/mainwindow.h
@@ -37,6 +37,8 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
+    MainWindow(const MainWindow&) = default ;
+    MainWindow& operator=(const MainWindow&) = default ;
     MainWindow();
 
     void setMarlinSteerCheck( const char* filename=NULL );
@@ -107,47 +109,47 @@ private:
     void checkCurrentStyle();
 
     //variables
-    bool _modified;
-    bool _saved;
-    std::string _file;
-    MarlinSteerCheck* msc;
+    bool _modified{};
+    bool _saved{};
+    std::string _file{};
+    MarlinSteerCheck* msc{};
 
     //group boxes
-    QGroupBox *aProcErrorsGBox;
-    QGroupBox *viewButtonsGBox;
-    QGroupBox *aProcButtonsGBox;
-    QGroupBox *iProcButtonsGBox;
-    QGroupBox *aProcGBox;
-    QGroupBox *iProcGBox;
-    QGroupBox *condGBox;
-    QGroupBox *lcioFilesGBox;
-    QGroupBox *lcioColsGBox;
-    QGroupBox *globalSectionGBox;
+    QGroupBox *aProcErrorsGBox{};
+    QGroupBox *viewButtonsGBox{};
+    QGroupBox *aProcButtonsGBox{};
+    QGroupBox *iProcButtonsGBox{};
+    QGroupBox *aProcGBox{};
+    QGroupBox *iProcGBox{};
+    QGroupBox *condGBox{};
+    QGroupBox *lcioFilesGBox{};
+    QGroupBox *lcioColsGBox{};
+    QGroupBox *globalSectionGBox{};
     
     //tables
-    QTableWidget *aProcTable;
-    QTableWidget *iProcTable;
-    QTableWidget *globalSectionTable;
-    QTableWidget *lcioColsTable;
-    QTableWidget *condTable;
-    QListWidget *lcioFilesList;
+    QTableWidget *aProcTable{};
+    QTableWidget *iProcTable{};
+    QTableWidget *globalSectionTable{};
+    QTableWidget *lcioColsTable{};
+    QTableWidget *condTable{};
+    QListWidget *lcioFilesList{};
 
     //toggle buttons
-    QPushButton *hideProcs;
-    QPushButton *hideErrors;
-    QPushButton *showCond;
+    QPushButton *hideProcs{};
+    QPushButton *hideErrors{};
+    QPushButton *showCond{};
     
     //splitters
-    QSplitter *vSplitter;
-    QSplitter *hSplitter;
-    QList<int> hSizes;
-    int hSplitterSize;
+    QSplitter *vSplitter{};
+    QSplitter *hSplitter{};
+    QList<int> hSizes{};
+    int hSplitterSize{};
     
     //other
-    QTextEdit *aProcErrors;
-    QString saveChangesMsg;
-    QString aboutGUIMsg;
-    QActionGroup *styleActionGroup;
+    QTextEdit *aProcErrors{};
+    QString saveChangesMsg{};
+    QString aboutGUIMsg{};
+    QActionGroup *styleActionGroup{};
 };
 
 #endif

--- a/source/gui/nparamvecset.h
+++ b/source/gui/nparamvecset.h
@@ -26,6 +26,8 @@ class NParamVecSet : public QWidget
     Q_OBJECT
 
 public:
+    NParamVecSet(const NParamVecSet&) = default ;
+    NParamVecSet& operator=(const NParamVecSet&) = default ;
     //constructor
     NParamVecSet(
 	    MarlinSteerCheck* msc,
@@ -43,13 +45,13 @@ private slots:
 
 private:
     //Variables
-    MarlinSteerCheck* _msc;
-    CCProcessor* _p;
-    QTableWidget* _parent;
-    QTableWidget* valTable;
-    QDialog* _dialog;
+    MarlinSteerCheck* _msc{};
+    CCProcessor* _p{};
+    QTableWidget* _parent{};
+    QTableWidget* valTable{};
+    QDialog* _dialog{};
     
-    QVBoxLayout *mainLayout; 
+    QVBoxLayout *mainLayout{}; 
 };
 
 #endif

--- a/source/gui/nparamvecsetd.h
+++ b/source/gui/nparamvecsetd.h
@@ -24,6 +24,8 @@ class NParamVecSetD : public QItemDelegate
     Q_OBJECT
 
 public:
+    NParamVecSetD(const NParamVecSetD&) = default ;
+    NParamVecSetD& operator=(const NParamVecSetD&) = default ;
     //constructor
     NParamVecSetD(
 	    MarlinSteerCheck *msc,

--- a/source/gui/ocoldelegate.h
+++ b/source/gui/ocoldelegate.h
@@ -22,6 +22,8 @@ class OColDelegate : public QItemDelegate
     Q_OBJECT
 
 public:
+    OColDelegate(const OColDelegate&) = default ;
+    OColDelegate& operator=(const OColDelegate&) = default ;
     OColDelegate(CCProcessor* p, MarlinSteerCheck* msc, QObject *parent = 0);
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -29,9 +31,9 @@ public:
     void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 
 private:
-    CCProcessor* _p;
-    MarlinSteerCheck* _msc;
-    QTableWidget* _parent;
+    CCProcessor* _p{};
+    MarlinSteerCheck* _msc{};
+    QTableWidget* _parent{};
 };
 
 #endif

--- a/source/gui/paramdelegate.h
+++ b/source/gui/paramdelegate.h
@@ -21,6 +21,8 @@ class ParamDelegate : public QItemDelegate
     Q_OBJECT
 
 public:
+    ParamDelegate(const ParamDelegate&) = default ;
+    ParamDelegate& operator=(const ParamDelegate&) = default ;
     ParamDelegate(CCProcessor* p, QObject *parent = 0);
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -28,8 +30,8 @@ public:
     void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 
 private:
-    CCProcessor* _p;
-    QTableWidget* _parent;
+    CCProcessor* _p{};
+    QTableWidget* _parent{};
 };
 
 #endif

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -186,11 +186,7 @@ int main(int argc, char** argv ){
     // read file name from command line
     if( argc > 1 ){
 
-        if( std::string(argv[1]) == "-l" ){
-            listAvailableProcessors() ;
-            return(0) ;
-        }
-        else if( std::string(argv[1]) == "-x" ){
+        if( std::string(argv[1]) == "-x" ){
             listAvailableProcessorsXML() ;
             return(0) ;
         }
@@ -216,28 +212,6 @@ int main(int argc, char** argv ){
 	    return(1);
 	  }
 	}
-        else if( std::string(argv[1]) == "-o" ){
-            if( argc == 4 ){
-                MarlinSteerCheck msc(argv[2], &cmdlineparams );
-                msc.saveAsXMLFile(argv[3]) ;
-                return(0) ;
-            }
-            else{
-                std::cout << "  usage: Marlin -o old.steer new.xml" << std::endl << std::endl;
-                return(1);
-            }
-        }
-        else if( std::string(argv[1]) == "-f" ){
-            if( argc == 4 ){
-                XMLFixCollTypes fixColTypes(argv[2]);
-                fixColTypes.parse(argv[3] );
-                return(0) ;
-            }
-            else{
-                std::cout << "  usage: Marlin -f oldsteering.xml newsteering.xml" << std::endl << std::endl;
-                return(1);
-            }
-        }
         else if( std::string(argv[1]) == "-d" ){
             if( argc == 4 ){
                 MarlinSteerCheck msc(argv[2], &cmdlineparams );
@@ -652,9 +626,6 @@ int printUsage() {
 	    << "   Marlin -c steer.xml        \t check the given steering file for consistency" << std::endl 
 	    << "   Marlin -u old.xml new.xml  \t consistency check with update of xml file"  << std::endl
 	    << "   Marlin -d steer.xml flow.dot\t create a program flow diagram (see: http://www.graphviz.org)" << std::endl 
-	    << "   Marlin -l                  \t [deprecated: old format steering file example]" << std::endl 
-	    << "   Marlin -f old.xml new.xml  \t [deprecated: convert old xml files to new xml files for consistency check]"  << std::endl 
-	    << "   Marlin -o old.steer new.xml\t [deprecated: convert old steering file to xml steering file]" << std::endl 
 	    << std::endl 
 	    << " Example: " << std::endl 
 	    << " To create a new default steering file from any Marlin application, run" << std::endl 
@@ -665,7 +636,7 @@ int printUsage() {
 	    << " Dynamic command line options may be specified in order to overwrite individual steering file parameters, e.g.:" << std::endl 
 	    << "     Marlin --global.LCIOInputFiles=\"input1.slcio input2.slcio\" --global.GearXMLFile=mydetector.xml" << std::endl 
 	    << "            --MyLCIOOutputProcessor.LCIOWriteMode=WRITE_APPEND --MyLCIOOutputProcessor.LCIOOutputFile=out.slcio steer.xml" << std::endl << std::endl
-	    << "     NOTE: Dynamic options do NOT work together with Marlin options (-x, -f, -l) nor with the MarlinGUI or old steering files" << std::endl 
+	    << "     NOTE: Dynamic options do NOT work together with Marlin options (-x, -f) nor with the MarlinGUI" << std::endl
 	    << std::endl ;
   
   return(0) ;

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -386,44 +386,6 @@ int main(int argc, char** argv ){
 
     if( gearFile.size() > 0 ) {
       
-
-
-      // //---------- check if we have an extension Gear file -------------------------
-
-      // StringVec gearExtFiles ; 
-
-      // if( (Global::parameters->getStringVals("GearExtensionFiles" , gearExtFiles ) ).size() == 2 ){
-	
-      // 	streamlog_out( MESSAGE ) << " ======== Extension Gear file given: " <<  gearExtFiles[0] << " ============= \n"
-      // 				 << "     will add its parameters to the original Gear file: "  << gearFile << "\n"
-      // 				 << "     resulting Gear file will be used and saved as:     "  << gearExtFiles[1] << "\n"
-      // 				 << " ========================================================================= " << std::endl ;
-	
-      // 	gear::MergeXML mergeXML ;
-	
-      // 	if( ! mergeXML.setFile1(  gearFile  )){
-	  
-      // 	  streamlog_out( ERROR ) << "  Could not read Gear file  " <<  gearFile << std::endl ;
-      // 	  exit(1) ;
-      // 	}
-	
-      // 	if( ! mergeXML.setFile2( gearExtFiles[0] )){
-	  
-      // 	  streamlog_out( ERROR ) << "  Could not read extension Gear file  " <<  gearExtFiles[0] << std::endl ;
-      // 	  exit(1) ;
-      // 	}
-	
-      // 	if( !  mergeXML.mergeFiles( gearExtFiles[1] )){
-	  
-      // 	  streamlog_out( ERROR ) << "  Could not write extended Gear file  " <<  gearExtFiles[1] << std::endl ;
-      // 	  exit(1) ;
-      // 	}
-	
-      // 	gearFile =  gearExtFiles[1] ;
-
-      // }
-      // //----------------------------------------------------------------------------
-      
       gear::GearXML gearXML( gearFile ) ;
       
       Global::GEAR = gearXML.createGearMgr() ;
@@ -433,7 +395,7 @@ int main(int argc, char** argv ){
       
     } else {
 
-        streamlog_out( WARNING ) << " ---- no GEAR XML file given  --------- " << std::endl ;
+        streamlog_out( MESSAGE ) << " ---- no GEAR XML file given  --------- " << std::endl ;
         Global::GEAR = new gear::GearMgrImpl ;
     }
 

--- a/source/src/ProcessorMgr.cc
+++ b/source/src/ProcessorMgr.cc
@@ -142,24 +142,30 @@ namespace marlin{
         typedef ProcessorMap::iterator MI ;
 
         std::cout  << "<!--##########################################" << std::endl
-            << "    #                                        #" << std::endl
-            << "    #     Example steering file for marlin   #" << std::endl
-            << "    #                                        #" << std::endl
-            << "    ##########################################-->" << std::endl
-            <<  std::endl ;
+		   << "    #                                        #" << std::endl
+		   << "    #     Example steering file for marlin   #" << std::endl
+		   << "    #                                        #" << std::endl
+		   << "    ##########################################-->" << std::endl
+		   <<  std::endl ;
 
         std::cout  <<  std::endl 
             << "<marlin xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
             << "xsi:noNamespaceSchemaLocation=\"http://ilcsoft.desy.de/marlin/marlin.xsd\">"
             <<  std::endl ;
 
+        std::cout  <<  " <constants>" << std::endl
+		   <<  "  <!-- define constants here - use in steering file as ${ConstantName} --> "  << std::endl
+		   <<  "  <!--constant name=\"DetectorModel\" value=\"ILD_l5_o1_v02\" /-->" << std::endl
+		   <<  " </constants>" << std::endl
+		   << std::endl ;
+
         std::cout  <<  " <execute>" << std::endl 
-		   << "  <XXprocessor name=\"MyEventSelector\"/> " << std::endl 
-		   << "  <XXif condition=\"MyEventSelector\">    " << std::endl 
+		   <<  "  <!--processor name=\"MyEventSelector\"/--> " << std::endl
+		   <<  "  <!--if condition=\"MyEventSelector\"-->    " << std::endl
 		   <<  "   <processor name=\"MyAIDAProcessor\"/>" << std::endl
 		   <<  "   <processor name=\"MyTestProcessor\"/>  " << std::endl
 		   <<  "   <processor name=\"MyLCIOOutputProcessor\"/>  " << std::endl
-		   << "  </XXif>                                 " << std::endl  
+		   << "  <!--/if-->                                 " << std::endl
 		   <<  " </execute>" << std::endl
 		   << std::endl ;
 
@@ -170,7 +176,7 @@ namespace marlin{
 		   <<  "  <parameter name=\"SkipNEvents\" value=\"0\" />  " << std::endl
 		   <<  "  <parameter name=\"SupressCheck\" value=\"false\" />  " << std::endl
 		   <<  "  <parameter name=\"AllowToModifyEvent\" value=\"false\" />  " << std::endl
-		   <<  "  <parameter name=\"GearXMLFile\"> gear_ldc.xml </parameter>  " << std::endl
+		   <<  "  <parameter name=\"GearXMLFile\"></parameter>  " << std::endl
 		   <<  "  <parameter name=\"Verbosity\" options=\"DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT\"> DEBUG  </parameter> " << std::endl
 		   <<  "  <parameter name=\"RandomSeed\" value=\"1234567890\" />" << std::endl
 		   <<  "  <!-- optionally limit the collections that are read from the input file: -->  " << std::endl


### PR DESCRIPTION

BEGINRELEASENOTES
- fix last compiler warnings in MarlinGUI and example (gcc5.4) 
- don't create MarlinLibDeps.cmake 
- rm Gear file from example steering and add <constants/> section 
- rm deprecated options (-l,-f,-o) involving old steering files 

ENDRELEASENOTES