### PR TITLE
allow parameters with dots to be changed on command line

### DIFF
--- a/source/include/marlin/Parser.h
+++ b/source/include/marlin/Parser.h
@@ -92,17 +92,18 @@ class LCTokenizer{
   std::vector< std::string >& _tokens ;
   char _del ;
   char _last ;
+  size_t _max ;
  public:
 
-  LCTokenizer( std::vector< std::string >& tokens, char del ) : _tokens(tokens) , _del(del), _last(del) {
+  LCTokenizer( std::vector< std::string >& tokens, char del, size_t max=-1 ) : _tokens(tokens) , _del(del), _last(del), _max(max) {
   }
 
 
   void operator()(const char& c) { 
 
-    if( c != _del  ) {
+    if( c != _del or _tokens.size() >= _max ) {
 
-	if( _last == _del  ) {
+	if( _last == _del and _tokens.size() < _max ) {
 	  _tokens.push_back("") ; 
 	}
       _tokens.back() += c ;

--- a/source/include/marlin/XMLParser.h
+++ b/source/include/marlin/XMLParser.h
@@ -116,17 +116,18 @@ namespace marlin{
       std::vector< std::string >& _tokens ;
       char _del ;
       char _last ;
+      size_t _max ;
     public:
 
-      LCTokenizer( std::vector< std::string >& tokens, char del ) : _tokens(tokens) , _del(del), _last(del) {
+      LCTokenizer( std::vector< std::string >& tokens, char del, size_t max=-1 ) : _tokens(tokens) , _del(del), _last(del), _max(max) {
       }
 
 
       void operator()(const char& c) { 
 
-	if( c != _del  ) {
+	if( c != _del or _tokens.size() >= _max ) {
 
-	  if( _last == _del  ) {
+	  if( _last == _del and _tokens.size() < _max ) {
 	    _tokens.push_back("") ; 
 	  }
 	  _tokens.back() += c ;

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -149,7 +149,7 @@ int main(int argc, char** argv ){
             // split first arg by '.'
             // --global.LCIOInputFiles --> global , LCIOInputFiles
             s = cmdlinearg[0] ;
-            LCTokenizer t2( cmdlinekey, '.' ) ;
+            LCTokenizer t2( cmdlinekey, '.', 2 ) ;
 
             for_each( s.begin(), s.end(), t2 ) ;
 


### PR DESCRIPTION
allows for changing LCFIPlus like parameters on command line

This would solve this problem lcfiplus/lcfiplus#3 without invalidating all the existing XML files. As there are additional checks that parameter names are in the XML file

BEGINRELEASENOTES
- Marlin command line arguments: parameter names may now contain dots, solves lcfiplus/lcfiplus#3
- LCTokenizer: add optional max parameter to limit the number of resulting tokens

ENDRELEASENOTES