### PR TITLE
fix "invalid read" errors from valgrind, prevent crash in XML parsing

### DIFF
--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -901,8 +901,9 @@ namespace marlin{
         }
 
         TiXmlNode* child = 0 ;
-        while( ( child = section->IterateChildren( child ) )  != 0  ){
-
+        TiXmlNode* nextChild = section->IterateChildren( child );
+        while((child = nextChild) != 0){
+            nextChild = section->IterateChildren(child);
             if( std::string( child->Value() )  == "group" ) {
 
                 // find group definition in root node 

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -527,9 +527,10 @@ namespace marlin{
             condition = aCondition ;
 
         TiXmlNode* child = 0 ;
-        while( ( child = current->IterateChildren( "if" , child )  )  != 0  ){
-
-            processconditions( child , getAttribute( child, "condition") ) ;  
+        TiXmlNode* nextChild = current->IterateChildren("if" , child);
+        while((child = nextChild) != 0){
+            nextChild = current->IterateChildren("if" , child);
+            processconditions( child , getAttribute( child, "condition") ) ; // might clean child
         }
 
         while( ( child = current->IterateChildren( "processor" , child )  )  != 0  ) {

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -157,7 +157,11 @@ namespace marlin{
         // preprocess groups: ---------------------------------------------------------------------------------
         // simply copy all group parameters to the processors
         // and then copy the processors to the root node <Marlin>
-        while( (section = root->IterateChildren( "group", section ) )  != 0  ){
+        // 'section' comes from above as first execute child, get the next section so we
+        // do not cleanup the execute section in loop body below, only the groups
+        TiXmlNode* nextSection = root->IterateChildren("group", section);
+        while((section = nextSection) != 0){
+            nextSection = root->IterateChildren("group", section);
 
             std::vector<TiXmlNode*> groupParams ;
 


### PR DESCRIPTION

BEGINRELEASENOTES
- XMLParser: Fix "random" crash during XML parsing. Depends on XML Steering file and memory runtime behaviour, when some freed memory is overwritten
  ```
   /Marlin/source/tinyxml/src/tinyxml.cc:377: const TiXmlNode* TiXmlNode::IterateChildren(const char*, const TiXmlNode*) const: Assertion `previous->parent == this' failed.
  ```
- XMLParser: Fix "invalid read errors" reported by valgrind. Objects were removed before they were used again, which probably lead to the above mentioned crashs

ENDRELEASENOTES

### crash

The crash can (maybe?) be reproduced with attached steering file (renamed to xml)
[break.txt](https://github.com/iLCSoft/Marlin/files/3013507/break.txt)
```
source /cvmfs/clicdp.cern.ch/iLCSoft/builds/2019-02-20/x86_64-slc6-gcc62-opt/init_ilcsoft.sh
wget https://github.com/iLCSoft/Marlin/files/3013507/break.txt -O break.xml
Marlin break.xml
```


### invalid read

Example valgrind output
```
==21315== Invalid read of size 8
==21315==    at 0x4ECA406: TiXmlNode::NextSibling(char const*) const (tinyxml.cc:386)
==21315==    by 0x4C8525B: IterateChildren (tinyxml.h:570)
==21315==    by 0x4C8525B: marlin::XMLParser::parse() (XMLParser.cc:160)
==21315==    by 0x40E5AE: main (Marlin.cc:277)
==21315==  Address 0x145894c0 is 96 bytes inside a block of size 216 free'd
==21315==    at 0x4A09186: operator delete(void*) (vg_replace_malloc.c:575)
==21315==    by 0x4ECA2F3: TiXmlNode::RemoveChild(TiXmlNode*) (tinyxml.cc:327)
==21315==    by 0x4C85417: marlin::XMLParser::parse() (XMLParser.cc:179)
==21315==    by 0x40E5AE: main (Marlin.cc:277)
==21315==  Block was alloc'd at
==21315==    at 0x4A080BC: operator new(unsigned long) (vg_replace_malloc.c:333)
==21315==    by 0x4ECF3A9: TiXmlNode::Identify(char const*, TiXmlEncoding) (tinyxmlparser.cc:892)
==21315==    by 0x4ED0C45: TiXmlElement::ReadValue(char const*, TiXmlParsingData*, TiXmlEncoding) (tinyxmlparser.cc:1229)
==21315==    by 0x4ED0FDE: TiXmlElement::Parse(char const*, TiXmlParsingData*, TiXmlEncoding) (tinyxmlparser.cc:1124)
==21315==    by 0x4ECF50C: TiXmlDocument::Parse(char const*, TiXmlParsingData*, TiXmlEncoding) (tinyxmlparser.cc:767)
==21315==    by 0x4ECAE0D: TiXmlDocument::LoadFile(_IO_FILE*, TiXmlEncoding) (tinyxml.cc:1077)
==21315==    by 0x4ECB0A6: TiXmlDocument::LoadFile(char const*, TiXmlEncoding) (tinyxml.cc:953)
==21315==    by 0x4C84002: LoadFile (tinyxml.h:1409)
==21315==    by 0x4C84002: marlin::XMLParser::parse() (XMLParser.cc:28)
==21315==    by 0x40E5AE: main (Marlin.cc:277)
```



