### PR TITLE
For Wrapping processors inside Gaudi

### DIFF
--- a/source/include/marlin/EventSelector.h
+++ b/source/include/marlin/EventSelector.h
@@ -23,6 +23,7 @@ using namespace marlin ;
  * @author F. Gaede, DESY
  * @version $Id:$ 
  */
+namespace marlin {
 
 class EventSelector : public Processor, public marlin::EventModifier {
   
@@ -72,6 +73,8 @@ class EventSelector : public Processor, public marlin::EventModifier {
   int _nRun=-1;
   int _nEvt=-1;
 } ;
+
+} // namespace marlin
 
 #endif
 

--- a/source/include/marlin/EventSelector.h
+++ b/source/include/marlin/EventSelector.h
@@ -25,54 +25,50 @@ using namespace marlin ;
  */
 namespace marlin {
 
-class EventSelector : public Processor, public marlin::EventModifier {
-  
-  typedef std::set< std::pair< int, int > > SET ;
+  class EventSelector : public Processor, public marlin::EventModifier {
 
- public:
-  
-  virtual Processor*  newProcessor() { return new EventSelector ; }
-  
-  
-  EventSelector() ;
-  
-  /** Called at the begin of the job before anything is read.
-   * Use to initialize the processor, e.g. book histograms.
-   */
-  virtual void init() ;
-  
-  /** Called for every run.
-   */
-  virtual void processRunHeader( LCRunHeader* run ) ;
-  
-  /** Called for every event - the working horse.
-   */
-  virtual void processEvent( LCEvent * evt ) ; 
-  
-  
-  virtual void check( LCEvent * evt ) ; 
-  
-  
-  virtual void modifyEvent( LCEvent *evt ) ;
-  
-  
-  /** Called after data processing for clean up.
-   */
-  virtual void end() ;
-  
-  virtual const std::string & name() const { return Processor::name() ; }
-  
-  
- protected:
+    typedef std::set< std::pair< int, int > > SET ;
 
-  /** Input collection name.
-   */
-  IntVec _evtList{};
-  SET _evtSet{};
+  public:
 
-  int _nRun=-1;
-  int _nEvt=-1;
-} ;
+    virtual Processor*  newProcessor() { return new EventSelector ; }
+
+    EventSelector() ;
+
+    /** Called at the begin of the job before anything is read.
+     * Use to initialize the processor, e.g. book histograms.
+     */
+    virtual void init() ;
+
+    /** Called for every run.
+     */
+    virtual void processRunHeader( LCRunHeader* run ) ;
+
+    /** Called for every event - the working horse.
+     */
+    virtual void processEvent( LCEvent * evt ) ;
+
+    virtual void check( LCEvent * evt ) ;
+
+    virtual void modifyEvent( LCEvent *evt ) ;
+
+    /** Called after data processing for clean up.
+     */
+    virtual void end() ;
+
+    virtual const std::string & name() const { return Processor::name() ; }
+
+
+  protected:
+
+    /** Input collection name.
+     */
+    IntVec _evtList{};
+    SET _evtSet{};
+
+    int _nRun=-1;
+    int _nEvt=-1;
+  } ;
 
 } // namespace marlin
 

--- a/source/include/marlin/Processor.h
+++ b/source/include/marlin/Processor.h
@@ -220,6 +220,12 @@ namespace marlin{
 //      */
 //     ProcessorParameter* getProcessorParameter( const std::string name) ;
     
+    /** Initialize the parameters */
+    virtual void setParameters( std::shared_ptr<StringParameters> parameters) ;
+
+    /** Set processor name */
+    virtual void setName( const std::string & processorName) { _processorName = processorName ; }
+
   protected:
 
     /** Set the return value for this processor - typically at end of processEvent(). 
@@ -409,12 +415,6 @@ namespace marlin{
     
     /** Allow friend class CCProcessor to update processor parameters */
     virtual void updateParameters();
-
-    /** Set processor name */
-    virtual void setName( const std::string & processorName) { _processorName = processorName ; }
-    
-    /** Initialize the parameters */
-    virtual void setParameters( std::shared_ptr<StringParameters> parameters) ;
     
     /** Sets the registered steering parameters before calling init() 
      */


### PR DESCRIPTION
These changes are needed to configure and run Marlin processors from a Gaudi Algorithm or avoid a clash in the naming of the EventSelector class

BEGINRELEASENOTES
- Marlin::Processor: make setParameters and setName public functions
- Marlin::EventSelector: moved to marlin namespace

ENDRELEASENOTES