### PR TITLE
Use new streamlog interface

### DIFF
--- a/source/include/marlin/Processor.h
+++ b/source/include/marlin/Processor.h
@@ -155,13 +155,17 @@ namespace marlin{
     template <class T>
     void printParameters() {
     
-      
+      // Can't use the streamlog macros
+      // as the compiler can't replace
+      // the template parameter in the streamlog macros.
+      // Use the global logger here
+      auto &logger = streamlog::logstream::global() ;
       //if( streamlog::out.template write<T>() ) {
 
 	
 	typedef ProcParamMap::iterator PMI ;
 
-	streamlog_out(T)  << std::endl  
+	logger.log<T>()  << std::endl  
 			<< "---- " << name()  <<" -  parameters: " << std::endl ;
 	
 	
@@ -169,14 +173,14 @@ namespace marlin{
 	  
 	  if( ! i->second->isOptional() || i->second->valueSet() ){
 	    //streamlog::out.template write<T>() ;
-	    streamlog_out(T) << "\t"   << i->second->name()   
+	    logger.log<T>() << "\t"   << i->second->name()   
 			     << ":  "  << i->second->value() 
 			     << std::endl ;
 	  }
 	}
 	
 	//streamlog::out.template write<T>() ;
-	streamlog_out(T) << "-------------------------------------------------" 
+	logger.log<T>() << "-------------------------------------------------" 
 			 << std::endl ;
 	
 	//}
@@ -365,7 +369,7 @@ namespace marlin{
       
 
       //if( streamlog::out.template write<T>() ) 
-	streamlog_out(T) << m << std::endl ;
+      streamlog::logstream::global().log<T>() << m << std::endl ;
       
     }
     

--- a/source/include/marlin/Processor.h
+++ b/source/include/marlin/Processor.h
@@ -156,30 +156,30 @@ namespace marlin{
     void printParameters() {
     
       
-      if( streamlog::out.template write<T>() ) {
+      //if( streamlog::out.template write<T>() ) {
 
 	
 	typedef ProcParamMap::iterator PMI ;
 
-	streamlog::out()  << std::endl  
+	streamlog_out(T)  << std::endl  
 			<< "---- " << name()  <<" -  parameters: " << std::endl ;
 	
 	
 	for( PMI i = _map.begin() ; i != _map.end() ; i ++ ) {
 	  
 	  if( ! i->second->isOptional() || i->second->valueSet() ){
-	    streamlog::out.template write<T>() ;
-	    streamlog::out() << "\t"   << i->second->name()   
+	    //streamlog::out.template write<T>() ;
+	    streamlog_out(T) << "\t"   << i->second->name()   
 			     << ":  "  << i->second->value() 
 			     << std::endl ;
 	  }
 	}
 	
-	streamlog::out.template write<T>() ;
-	streamlog::out() << "-------------------------------------------------" 
+	//streamlog::out.template write<T>() ;
+	streamlog_out(T) << "-------------------------------------------------" 
 			 << std::endl ;
 	
-      }
+	//}
     }
 
     /** Print the parameters and their values with verbosity level MESSAGE.
@@ -364,8 +364,8 @@ namespace marlin{
     void message(  const std::string& m ) const {
       
 
-      if( streamlog::out.template write<T>() ) 
-	streamlog::out() << m << std::endl ;
+      //if( streamlog::out.template write<T>() ) 
+	streamlog_out(T) << m << std::endl ;
       
     }
     
@@ -385,25 +385,25 @@ namespace marlin{
      * @see std::stringstream& log()
      */
 
-    template <class T>
-    inline void message( const std::basic_ostream<char, std::char_traits<char> >& m) const {
+    /* template <class T> */
+    /* inline void message( const std::basic_ostream<char, std::char_traits<char> >& m) const { */
 
-     if( T::active ){  // allow the compiler to optimize this away ...
+    /*  if( T::active ){  // allow the compiler to optimize this away ... */
 
-       try{
-	 const std::stringstream& mess = dynamic_cast<const std::stringstream&>( m ) ; 
+    /*    try{ */
+    /* 	 const std::stringstream& mess = dynamic_cast<const std::stringstream&>( m ) ;  */
 
-	 this->template message<T>( mess.str() ) ;
+    /* 	 this->template message<T>( mess.str() ) ; */
 
-       }
-       catch( std::bad_cast ) {}
-     }
-    }
+    /*    } */
+    /*    catch( std::bad_cast ) {} */
+    /*  } */
+    /* } */
 
     /** Returns an empty stringstream that is used by the message method.
      * @deprecated
      */
-    std::stringstream& log() const ;
+    /* std::stringstream& log() const ; */
 
 
   private: // called by ProcessorMgr
@@ -462,7 +462,6 @@ namespace marlin{
     std::string _logLevelName{};
     
   private:
-    mutable std::stringstream* _str=NULL;
 
     Processor() ; 
   

--- a/source/src/Marlin.cc
+++ b/source/src/Marlin.cc
@@ -251,8 +251,9 @@ int main(int argc, char** argv ){
     //###### init streamlog ######
     std::string binname = argv[0]  ;
     binname = binname.substr( binname.find_last_of("/") + 1 , binname.size() ) ;
-    streamlog::out.init( std::cout , binname ) ;
-
+    auto &logger = streamlog::logstream::global() ;
+    logger.setName( binname ) ;
+    logger.setSinks( { streamlog::logstream::console() } ) ;
 
 
     std::unique_ptr<IParser> parser;
@@ -298,58 +299,59 @@ int main(int argc, char** argv ){
     }
 
     // //-----  register log level names with the logstream ---------
-    streamlog::out.addLevelName<DEBUG>() ;
-    streamlog::out.addLevelName<DEBUG0>() ;
-    streamlog::out.addLevelName<DEBUG1>() ;
-    streamlog::out.addLevelName<DEBUG2>() ;
-    streamlog::out.addLevelName<DEBUG3>() ;
-    streamlog::out.addLevelName<DEBUG4>() ;
-    streamlog::out.addLevelName<DEBUG5>() ;
-    streamlog::out.addLevelName<DEBUG6>() ;
-    streamlog::out.addLevelName<DEBUG7>() ;
-    streamlog::out.addLevelName<DEBUG8>() ;
-    streamlog::out.addLevelName<DEBUG9>() ;
-    streamlog::out.addLevelName<MESSAGE>() ;
-    streamlog::out.addLevelName<MESSAGE0>() ;
-    streamlog::out.addLevelName<MESSAGE1>() ;
-    streamlog::out.addLevelName<MESSAGE2>() ;
-    streamlog::out.addLevelName<MESSAGE3>() ;
-    streamlog::out.addLevelName<MESSAGE4>() ;
-    streamlog::out.addLevelName<MESSAGE5>() ;
-    streamlog::out.addLevelName<MESSAGE6>() ;
-    streamlog::out.addLevelName<MESSAGE7>() ;
-    streamlog::out.addLevelName<MESSAGE8>() ;
-    streamlog::out.addLevelName<MESSAGE9>() ;
-    streamlog::out.addLevelName<WARNING>() ;
-    streamlog::out.addLevelName<WARNING0>() ;
-    streamlog::out.addLevelName<WARNING1>() ;
-    streamlog::out.addLevelName<WARNING2>() ;
-    streamlog::out.addLevelName<WARNING3>() ;
-    streamlog::out.addLevelName<WARNING4>() ;
-    streamlog::out.addLevelName<WARNING5>() ;
-    streamlog::out.addLevelName<WARNING6>() ;
-    streamlog::out.addLevelName<WARNING7>() ;
-    streamlog::out.addLevelName<WARNING8>() ;
-    streamlog::out.addLevelName<WARNING9>() ;
-    streamlog::out.addLevelName<ERROR>() ;
-    streamlog::out.addLevelName<ERROR0>() ;
-    streamlog::out.addLevelName<ERROR1>() ;
-    streamlog::out.addLevelName<ERROR2>() ;
-    streamlog::out.addLevelName<ERROR3>() ;
-    streamlog::out.addLevelName<ERROR4>() ;
-    streamlog::out.addLevelName<ERROR5>() ;
-    streamlog::out.addLevelName<ERROR6>() ;
-    streamlog::out.addLevelName<ERROR7>() ;
-    streamlog::out.addLevelName<ERROR8>() ;
-    streamlog::out.addLevelName<ERROR9>() ;
-    streamlog::out.addLevelName<SILENT>() ;
+    // streamlog::out.addLevelName<DEBUG>() ;
+    // streamlog::out.addLevelName<DEBUG0>() ;
+    // streamlog::out.addLevelName<DEBUG1>() ;
+    // streamlog::out.addLevelName<DEBUG2>() ;
+    // streamlog::out.addLevelName<DEBUG3>() ;
+    // streamlog::out.addLevelName<DEBUG4>() ;
+    // streamlog::out.addLevelName<DEBUG5>() ;
+    // streamlog::out.addLevelName<DEBUG6>() ;
+    // streamlog::out.addLevelName<DEBUG7>() ;
+    // streamlog::out.addLevelName<DEBUG8>() ;
+    // streamlog::out.addLevelName<DEBUG9>() ;
+    // streamlog::out.addLevelName<MESSAGE>() ;
+    // streamlog::out.addLevelName<MESSAGE0>() ;
+    // streamlog::out.addLevelName<MESSAGE1>() ;
+    // streamlog::out.addLevelName<MESSAGE2>() ;
+    // streamlog::out.addLevelName<MESSAGE3>() ;
+    // streamlog::out.addLevelName<MESSAGE4>() ;
+    // streamlog::out.addLevelName<MESSAGE5>() ;
+    // streamlog::out.addLevelName<MESSAGE6>() ;
+    // streamlog::out.addLevelName<MESSAGE7>() ;
+    // streamlog::out.addLevelName<MESSAGE8>() ;
+    // streamlog::out.addLevelName<MESSAGE9>() ;
+    // streamlog::out.addLevelName<WARNING>() ;
+    // streamlog::out.addLevelName<WARNING0>() ;
+    // streamlog::out.addLevelName<WARNING1>() ;
+    // streamlog::out.addLevelName<WARNING2>() ;
+    // streamlog::out.addLevelName<WARNING3>() ;
+    // streamlog::out.addLevelName<WARNING4>() ;
+    // streamlog::out.addLevelName<WARNING5>() ;
+    // streamlog::out.addLevelName<WARNING6>() ;
+    // streamlog::out.addLevelName<WARNING7>() ;
+    // streamlog::out.addLevelName<WARNING8>() ;
+    // streamlog::out.addLevelName<WARNING9>() ;
+    // streamlog::out.addLevelName<ERROR>() ;
+    // streamlog::out.addLevelName<ERROR0>() ;
+    // streamlog::out.addLevelName<ERROR1>() ;
+    // streamlog::out.addLevelName<ERROR2>() ;
+    // streamlog::out.addLevelName<ERROR3>() ;
+    // streamlog::out.addLevelName<ERROR4>() ;
+    // streamlog::out.addLevelName<ERROR5>() ;
+    // streamlog::out.addLevelName<ERROR6>() ;
+    // streamlog::out.addLevelName<ERROR7>() ;
+    // streamlog::out.addLevelName<ERROR8>() ;
+    // streamlog::out.addLevelName<ERROR9>() ;
+    // streamlog::out.addLevelName<SILENT>() ;
 
 
     //-------- init logging level ------------
     std::string verbosity = Global::parameters->getStringVal("Verbosity" ) ;
-    streamlog::logscope scope( streamlog::out ) ;
+    // streamlog::logscope scope( streamlog::out ) ;
 
-    scope.setLevel( verbosity ) ;
+    // scope.setLevel( verbosity ) ;
+    logger.setLevel( verbosity ) ;
 
     createProcessors( *parser ) ;
 

--- a/source/src/Processor.cc
+++ b/source/src/Processor.cc
@@ -16,8 +16,7 @@ namespace marlin{
     _typeName( typeName ) ,
     _parameters(0) ,
     _isFirstEvent( true ),
-    _logLevelName(""),
-    _str(0) {
+    _logLevelName("") {
   
     //register processor in map
     ProcessorMgr::instance()->registerProcessor( this ) ;
@@ -31,12 +30,9 @@ namespace marlin{
   }
 
 
-  Processor::Processor() : _parameters(NULL), _isFirstEvent(false), _str(NULL) {}
+  Processor::Processor() : _parameters(NULL), _isFirstEvent(false) {}
 
   Processor::~Processor() {
-
-    if( _str !=0 )
-      delete _str ;
   
     typedef ProcParamMap::iterator PMI ;
   
@@ -66,16 +62,6 @@ namespace marlin{
     // 			  << " parameterSet : " << parameterSet("Verbosity") 
     // 			  << " log level name : " << _logLevelName << std::endl ; 
     
-  }
-  
-  std::stringstream& Processor::log() const {
-    
-    if( _str !=0 )
-      delete _str ;
-
-    _str = new std::stringstream ;
-
-    return *_str ;
   }
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Uses new streamlog interface (thread-safe)
- Removed method `Processor::message()` with ostream overload. Kept the one with std::string
- Removed method `Processor::log()`
- Removed static member `Processor::_str`. Not used anymore

ENDRELEASENOTES

Requires https://github.com/iLCSoft/iLCUtil/pull/14