### PR TITLE
Fix LCIO output compression level

### DIFF
--- a/source/include/marlin/LCIOOutputProcessor.h
+++ b/source/include/marlin/LCIOOutputProcessor.h
@@ -103,7 +103,7 @@ namespace marlin{
     LCWriter* _lcWrt=NULL;
     int _nRun=-1;
     int _nEvt=-1;
-    int _compressionLevel{-1};
+    int _compressionLevel{6};
 
   private:
   

--- a/source/src/LCIOOutputProcessor.cc
+++ b/source/src/LCIOOutputProcessor.cc
@@ -97,9 +97,9 @@ namespace marlin{
 			       1992294 ) ;  // 1.9 GB in kB
              
     registerOptionalParameter( "CompressionLevel" , 
-			       "The ZLIB compression level on writing"  ,
+			       "The ZLIB compression level on writing. Set it to 0 for no compression"  ,
 			       _compressionLevel, 
-			       _compressionLevel ) ;  // -1 by default
+			       _compressionLevel ) ;  // 6 by default
 
   }
 
@@ -119,9 +119,7 @@ void LCIOOutputProcessor::init() {
     _lcWrt = LCFactory::getInstance()->createLCWriter() ;
   }
   
-  if( parameterSet("CompressionLevel") ) {
-    _lcWrt->setCompressionLevel( _compressionLevel ) ;
-  }
+  _lcWrt->setCompressionLevel( _compressionLevel ) ;
 
 
   if( _lcioWriteMode == "WRITE_APPEND" ) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Set LCIO output compression to ON by default, and compression level to 6 (ZLIB default)

ENDRELEASENOTES