### PR TITLE
Fix shadowing proper parameter values by the xml comments elements

### DIFF
--- a/source/include/jenkinsHash.h
+++ b/source/include/jenkinsHash.h
@@ -109,17 +109,17 @@ unsigned jenkins_hash ( unsigned char *k, unsigned length, unsigned initval )
   c += length;
   
   switch ( len ) {
-  case 11: c += ( (unsigned)k[10] << 24 );
-  case 10: c += ( (unsigned)k[9] << 16 );
-  case 9 : c += ( (unsigned)k[8] << 8 );
+  case 11: c += ( (unsigned)k[10] << 24 ); [[fallthrough]];
+  case 10: c += ( (unsigned)k[9] << 16 ); [[fallthrough]];
+  case 9 : c += ( (unsigned)k[8] << 8 ); [[fallthrough]];
     /* First byte of c reserved for length */
-  case 8 : b += ( (unsigned)k[7] << 24 );
-  case 7 : b += ( (unsigned)k[6] << 16 );
-  case 6 : b += ( (unsigned)k[5] << 8 );
-  case 5 : b += k[4];
-  case 4 : a += ( (unsigned)k[3] << 24 );
-  case 3 : a += ( (unsigned)k[2] << 16 );
-  case 2 : a += ( (unsigned)k[1] << 8 );
+  case 8 : b += ( (unsigned)k[7] << 24 ); [[fallthrough]];
+  case 7 : b += ( (unsigned)k[6] << 16 ); [[fallthrough]];
+  case 6 : b += ( (unsigned)k[5] << 8 ); [[fallthrough]];
+  case 5 : b += k[4]; [[fallthrough]];
+  case 4 : a += ( (unsigned)k[3] << 24 ); [[fallthrough]];
+  case 3 : a += ( (unsigned)k[2] << 16 ); [[fallthrough]];
+  case 2 : a += ( (unsigned)k[1] << 8 ); [[fallthrough]];
   case 1 : a += k[0];
   }
   

--- a/source/src/ConditionsProcessor.cc
+++ b/source/src/ConditionsProcessor.cc
@@ -35,7 +35,7 @@ namespace marlin{
       lccd::LCConditionsMgr::instance()->registerChangeListener( cl , name ) ;
       return true ;
     }
-    catch(Exception){}
+    catch(Exception&){}
     
     return false ;
   }

--- a/source/src/ProcessorMgr.cc
+++ b/source/src/ProcessorMgr.cc
@@ -316,7 +316,7 @@ namespace marlin{
             gearDetName = Global::GEAR->getDetectorName()  ; 
 
         }
-        catch( gear::UnknownParameterException ){ 
+        catch( gear::UnknownParameterException& ){ 
 
             doConsistencyCheck = false ;
         }

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -384,7 +384,7 @@ namespace marlin{
             try{
                 inputLine = getAttribute( par , "value" );
             }      
-            catch( ParseException ){
+            catch( ParseException& ){
                 for( TiXmlNode* child = par->FirstChild(); child; child = child->NextSibling() ){
                     if( child->Type() == TiXmlNode::COMMENT) continue;
                     if ( !inputLine.empty() ) inputLine.append(" ");
@@ -432,7 +432,7 @@ namespace marlin{
         if( par->ToElement() )
           par->ToElement()->SetAttribute( "value", inputLine );
       }      
-      catch( ParseException ) {
+      catch( ParseException& ) {
 
           if( par->FirstChild() )
               par->FirstChild()->SetValue( inputLine ) ;
@@ -478,7 +478,7 @@ namespace marlin{
                 lcioInTypes.push_back( colType ) ; 
 
             }      
-            catch( ParseException ) { }
+            catch( ParseException& ) { }
 
             try{  
 
@@ -488,7 +488,7 @@ namespace marlin{
                 lcioOutTypes.push_back( colType ) ; 
 
             }      
-            catch( ParseException ) { }
+            catch( ParseException& ) { }
 
 
 

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -314,10 +314,11 @@ namespace marlin{
 
     const char* XMLParser::getAttribute( TiXmlNode* node , const std::string& name ){
 
+        if( node->Type() == TiXmlNode::COMMENT)
+            throw ParseException("XMLParser::getAttribute skipping XMLComment" ) ;
         TiXmlElement* el = node->ToElement() ;
         if( el == 0 ) 
             throw ParseException("XMLParser::getAttribute not an XMLElement " ) ;
-
         const char* at = el->Attribute( name.c_str() )  ;
 
         if( at == 0 ){
@@ -380,18 +381,16 @@ namespace marlin{
 
             std::string inputLine("") ;
 
-
-            try{  inputLine = getAttribute( par , "value" )  ; 
+            try{
+                inputLine = getAttribute( par , "value" );
             }      
-            catch( ParseException ) {
-
-                if( par->FirstChild() )
-                    inputLine =  par->FirstChild()->Value() ;
+            catch( ParseException ){
+                for( TiXmlNode* child = par->FirstChild(); child; child = child->NextSibling() ){
+                    if( child->Type() == TiXmlNode::COMMENT) continue;
+                    if ( !inputLine.empty() ) inputLine.append(" ");
+                    inputLine.append( child->Value() );
+                }
             }
-            
-
-            
-
             
             //       if( par->ToElement()->Attribute("value") != 0 ) {
             // 	inputLine = par->ToElement()->Attribute("value") ;
@@ -963,5 +962,3 @@ namespace marlin{
     }  
 
 }  // namespace marlin
-
-

--- a/test/marlintest/include/TestCommentParsingProcessor.h
+++ b/test/marlintest/include/TestCommentParsingProcessor.h
@@ -27,6 +27,7 @@ private:
   std::vector<std::string> m_mixedComment{};
   std::vector<std::string> m_noComment{};
   std::vector<std::string> m_onlyComment{};
+  std::vector<std::string> m_explicitValue{};
 };
 
 #endif

--- a/test/marlintest/include/TestCommentParsingProcessor.h
+++ b/test/marlintest/include/TestCommentParsingProcessor.h
@@ -1,0 +1,32 @@
+#ifndef TestCommentParsingProcessor_h
+#define TestCommentParsingProcessor_h
+
+#include "marlin/Processor.h"
+
+#include "lcio.h"
+
+#include <string>
+#include <vector>
+
+/** Test processor for Marlin that can be used to check whether comments in the
+ * xml steering files are handled correctly (and as expected).
+ *
+ */
+class TestCommentParsingProcessor : public marlin::Processor {
+public:
+  Processor *newProcessor() override { return new TestCommentParsingProcessor; }
+
+  TestCommentParsingProcessor();
+
+  void init() override;
+
+private:
+  /// Vectors for different parameters that are read from the steering file
+  std::vector<std::string> m_leadingComment{};
+  std::vector<std::string> m_trailingComment{};
+  std::vector<std::string> m_mixedComment{};
+  std::vector<std::string> m_noComment{};
+  std::vector<std::string> m_onlyComment{};
+};
+
+#endif

--- a/test/marlintest/src/TestCommentParsingProcesser.cc
+++ b/test/marlintest/src/TestCommentParsingProcesser.cc
@@ -27,13 +27,18 @@ TestCommentParsingProcessor::TestCommentParsingProcessor()
                              "A parameter where we test no comments",
                              m_noComment, defaultEmpty);
 
+  std::vector<std::string> defaultFilled = {"Non", "empty", "string", "vec"};
   registerProcessorParameter("onlyComment",
                              "A parameter where we test only comments",
-                             m_onlyComment, defaultEmpty);
+                             m_onlyComment, defaultFilled);
+
+  registerProcessorParameter(
+      "explicitValue", "A parameter that we pass in via an explicit value",
+      m_explicitValue, defaultEmpty);
 }
 
 std::ostream &operator<<(std::ostream &os, std::vector<std::string> stringVec) {
-  os << "(";
+  os << "{";
   if (!stringVec.empty()) {
     os << stringVec[0];
   }
@@ -41,35 +46,16 @@ std::ostream &operator<<(std::ostream &os, std::vector<std::string> stringVec) {
     os << ", " << stringVec[i];
   }
 
-  return os << ")";
+  return os << "}";
 }
 
 void TestCommentParsingProcessor::init() {
-  streamlog_out(MESSAGE) << "Got the following number of elements (leading | "
-                            "trailing | mixed | no | only): "
-                         << m_leadingComment.size() << " | "
-                         << m_trailingComment.size() << " | "
-                         << m_mixedComment.size() << " | " << m_noComment.size()
-                         << " | " << m_onlyComment.size() << std::endl;
-
-  // This output makes for an easier to grep output from CTest
-  streamlog_out(MESSAGE) << "GREPPABLE OUTPUT " << m_leadingComment.size()
-                         << ", " << m_trailingComment.size() << ", "
-                         << m_mixedComment.size() << ", " << m_noComment.size()
-                         << ", " << m_onlyComment.size() << std::endl;
-
-  streamlog_out(DEBUG) << "The leading comment parameter contents are: "
-                       << m_leadingComment << std::endl;
-
-  streamlog_out(DEBUG) << "The trailing comment parameter contents are: "
-                       << m_trailingComment << std::endl;
-
-  streamlog_out(DEBUG) << "The mixed comment parameter contents are: "
-                       << m_mixedComment << std::endl;
-
-  streamlog_out(DEBUG) << "The no comment parameter contents are: "
-                       << m_noComment << std::endl;
-
-  streamlog_out(DEBUG) << "The only comment parameter contents are: "
-                       << m_onlyComment << std::endl;
+  // Dump all values to the screen in a way that can be easily tested via
+  // CMake/CTest RegEx
+  streamlog_out(MESSAGE) << "LEADING " << m_leadingComment << std::endl;
+  streamlog_out(MESSAGE) << "MIXED " << m_mixedComment << std::endl;
+  streamlog_out(MESSAGE) << "TRAILING " << m_trailingComment << std::endl;
+  streamlog_out(MESSAGE) << "NO " << m_noComment << std::endl;
+  streamlog_out(MESSAGE) << "ONLY " << m_onlyComment << std::endl;
+  streamlog_out(MESSAGE) << "EXPLICIT " << m_explicitValue << std::endl;
 }

--- a/test/marlintest/src/TestCommentParsingProcesser.cc
+++ b/test/marlintest/src/TestCommentParsingProcesser.cc
@@ -46,11 +46,17 @@ std::ostream &operator<<(std::ostream &os, std::vector<std::string> stringVec) {
 
 void TestCommentParsingProcessor::init() {
   streamlog_out(MESSAGE) << "Got the following number of elements (leading | "
-                            "trailing | mixed | no): "
+                            "trailing | mixed | no | only): "
                          << m_leadingComment.size() << " | "
                          << m_trailingComment.size() << " | "
                          << m_mixedComment.size() << " | " << m_noComment.size()
-                         << std::endl;
+                         << " | " << m_onlyComment.size() << std::endl;
+
+  // This output makes for an easier to grep output from CTest
+  streamlog_out(MESSAGE) << "GREPPABLE OUTPUT " << m_leadingComment.size()
+                         << ", " << m_trailingComment.size() << ", "
+                         << m_mixedComment.size() << ", " << m_noComment.size()
+                         << ", " << m_onlyComment.size() << std::endl;
 
   streamlog_out(DEBUG) << "The leading comment parameter contents are: "
                        << m_leadingComment << std::endl;

--- a/test/marlintest/src/TestCommentParsingProcesser.cc
+++ b/test/marlintest/src/TestCommentParsingProcesser.cc
@@ -1,0 +1,69 @@
+#include "TestCommentParsingProcessor.h"
+
+#include "marlin/VerbosityLevels.h"
+
+TestCommentParsingProcessor aTestCommentParsingProcessor;
+
+TestCommentParsingProcessor::TestCommentParsingProcessor()
+    : marlin::Processor("TestCommentParsingProcessor") {
+  _description = "TestCommentParsingProcessor can be used to check whether "
+                 "comments in the xml steering files are correctly handled";
+
+  std::vector<std::string> defaultEmpty{};
+
+  registerProcessorParameter("leadingComment",
+                             "A parameter where we test leading comments",
+                             m_leadingComment, defaultEmpty);
+
+  registerProcessorParameter("trailingComment",
+                             "A parameter where we test trailing comments",
+                             m_trailingComment, defaultEmpty);
+
+  registerProcessorParameter("mixedComment",
+                             "A parameter where we test mixed comments",
+                             m_mixedComment, defaultEmpty);
+
+  registerProcessorParameter("noComment",
+                             "A parameter where we test no comments",
+                             m_noComment, defaultEmpty);
+
+  registerProcessorParameter("onlyComment",
+                             "A parameter where we test only comments",
+                             m_onlyComment, defaultEmpty);
+}
+
+std::ostream &operator<<(std::ostream &os, std::vector<std::string> stringVec) {
+  os << "(";
+  if (!stringVec.empty()) {
+    os << stringVec[0];
+  }
+  for (size_t i = 1; i < stringVec.size(); ++i) {
+    os << ", " << stringVec[i];
+  }
+
+  return os << ")";
+}
+
+void TestCommentParsingProcessor::init() {
+  streamlog_out(MESSAGE) << "Got the following number of elements (leading | "
+                            "trailing | mixed | no): "
+                         << m_leadingComment.size() << " | "
+                         << m_trailingComment.size() << " | "
+                         << m_mixedComment.size() << " | " << m_noComment.size()
+                         << std::endl;
+
+  streamlog_out(DEBUG) << "The leading comment parameter contents are: "
+                       << m_leadingComment << std::endl;
+
+  streamlog_out(DEBUG) << "The trailing comment parameter contents are: "
+                       << m_trailingComment << std::endl;
+
+  streamlog_out(DEBUG) << "The mixed comment parameter contents are: "
+                       << m_mixedComment << std::endl;
+
+  streamlog_out(DEBUG) << "The no comment parameter contents are: "
+                       << m_noComment << std::endl;
+
+  streamlog_out(DEBUG) << "The only comment parameter contents are: "
+                       << m_onlyComment << std::endl;
+}

--- a/test/marlintest/src/TestProcessorEventSeeder.cc
+++ b/test/marlintest/src/TestProcessorEventSeeder.cc
@@ -60,7 +60,7 @@ void TestProcessorEventSeeder::processEvent( LCEvent * evt ) {
   try{
     Global::EVENTSEEDER->registerProcessor(this);
   }
-  catch( lcio::Exception ) {
+  catch( lcio::Exception& ) {
   
   }
 
@@ -122,4 +122,3 @@ void TestProcessorEventSeeder::end(){
 			  << std::endl ;
   
 }
-

--- a/test/testmarlin/CMakeLists.txt
+++ b/test/testmarlin/CMakeLists.txt
@@ -63,3 +63,16 @@ SET_TESTS_PROPERTIES( t_includeandconstants PROPERTIES PASS_REGULAR_EXPRESSION "
 
 
 #---------------------------------------------------------------------------------------
+
+SET( MARLIN_STEERING_FILE parse_steering_comments.xml )
+SET( MARLIN_INPUT_FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/${MARLIN_STEERING_FILE}
+  ${CMAKE_CURRENT_SOURCE_DIR}/gear_simjob.xml
+  ${CMAKE_CURRENT_SOURCE_DIR}/simjob.slcio
+)
+CONFIGURE_FILE( runmarlin.cmake.in parse_steering_comments.cmake @ONLY )
+ADD_TEST( t_parse_steering_comments "${CMAKE_COMMAND}" -P parse_steering_comments.cmake )
+
+# The numbers are determined from simply counting the elements in the
+# parse_steering_comments.xml steering file
+SET_TESTS_PROPERTIES( t_parse_steering_comments PROPERTIES PASS_REGULAR_EXPRESSION "GREPPABLE OUTPUT 7, 2, 11, 9, 0")

--- a/test/testmarlin/CMakeLists.txt
+++ b/test/testmarlin/CMakeLists.txt
@@ -75,4 +75,9 @@ ADD_TEST( t_parse_steering_comments "${CMAKE_COMMAND}" -P parse_steering_comment
 
 # The numbers are determined from simply counting the elements in the
 # parse_steering_comments.xml steering file
-SET_TESTS_PROPERTIES( t_parse_steering_comments PROPERTIES PASS_REGULAR_EXPRESSION "GREPPABLE OUTPUT 7, 2, 11, 9, 0")
+SET_TESTS_PROPERTIES( t_parse_steering_comments PROPERTIES PASS_REGULAR_EXPRESSION "LEADING {But, we, also, have, real, input}")
+SET_TESTS_PROPERTIES( t_parse_steering_comments PROPERTIES PASS_REGULAR_EXPRESSION "MIXED {We, start, off, But, we, continue, and, finally, end, with, content}")
+SET_TESTS_PROPERTIES( t_parse_steering_comments PROPERTIES PASS_REGULAR_EXPRESSION "NO {Obviously, things, work, if, we, put, in, no, comment}")
+SET_TESTS_PROPERTIES( t_parse_steering_comments PROPERTIES PASS_REGULAR_EXPRESSION "ONLY {}")
+SET_TESTS_PROPERTIES( t_parse_steering_comments PROPERTIES PASS_REGULAR_EXPRESSION "TRAILING {Content, first}")
+SET_TESTS_PROPERTIES( t_parse_steering_comments PROPERTIES PASS_REGULAR_EXPRESSION "EXPLICIT {Hello, It, Is, Me}")

--- a/test/testmarlin/parse_steering_comments.xml
+++ b/test/testmarlin/parse_steering_comments.xml
@@ -46,6 +46,8 @@
     Content first
     <!-- Apologize later -->
   </parameter>
+  <!-- A parameter that we pass in via an explicit value -->
+  <parameter name="explicitValue" type="StringVec" value="Hello It Is Me"/>
 </processor>
 
 </marlin>

--- a/test/testmarlin/parse_steering_comments.xml
+++ b/test/testmarlin/parse_steering_comments.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="us-ascii"?>
+
+<marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
+
+ <execute>
+   <processor name="MyTestCommentParsingProcessor"/>
+  <!--/if-->
+ </execute>
+
+ <global>
+  <parameter name="LCIOInputFiles"> simjob.slcio </parameter>
+  <parameter name="MaxRecordNumber" value="4" />
+  <parameter name="GearXMLFile">gear_simjob.xml</parameter>
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> DEBUG  </parameter>
+ </global>
+
+  <!-- Here we feed this processor with a fixed input and make CTest check that
+       the output of running this is as expected, i.e. we have the expected
+       number of elements in each of the parameters -->
+  <processor name="MyTestCommentParsingProcessor" type="TestCommentParsingProcessor">
+  <parameter name="leadingComment" type="StringVec">
+    <!-- Here we have a leading comment -->
+    <!-- and even a second one -->
+    But we also have a real input
+  </parameter>
+  <!--A parameter where we test mixed comments-->
+  <parameter name="mixedComment" type="StringVec">
+    We start off
+    <!-- then we add a comment -->
+    But we continue
+    <!-- before we put in some more comments -->
+    and finally end with content
+  </parameter>
+  <!--A parameter where we test no comments-->
+  <parameter name="noComment" type="StringVec">
+    Obviously things work if we put in no comment
+  </parameter>
+  <!--A parameter where we test only comments-->
+  <parameter name="onlyComment" type="StringVec">
+    <!-- Having only comments should work as well -->
+    <!-- Even if there are multiple of them -->
+    <!-- And as we all know, three's a crowd -->
+  </parameter>
+  <!--A parameter where we test trailing comments-->
+  <parameter name="trailingComment" type="StringVec">
+    Content first
+    <!-- Apologize later -->
+  </parameter>
+</processor>
+
+</marlin>


### PR DESCRIPTION
BEGINRELEASENOTES

- Fix #43, a bug where xml comment fields were processed as a legitimate values and shadowed any data that comes after the comment.

ENDRELEASENOTES

### Tests
___
**steer.xml**
```xml
	<parameter name="LCIOInputFiles">
            <!-- test_comment -->
            data_test1.slcio
            data_test2.slcio
            data_test3.slcio
        </parameter>
```
**Before PR:**
```
 ***********************************************
 A runtime error occured - (uncaught exception):
      /cvmfs/ilc.desy.de/sw/x86_64_gcc82_centos7/v02-02-03/lcio/v02-17/src/cpp/src/MT/LCReader.cc (l.49) in open: Couldn't open input stream 'test_comment' [not_open]
 Marlin will have to be terminated, sorry.
 ***********************************************
```
**After PR:**
```
LCIO Input Files:
data_test1.slcio
data_test2.slcio
data_test3.slcio
```

___

**steer.xml**
```xml
	<parameter name="LCIOInputFiles">
            data_test1.slcio
            data_test2.slcio
            <!-- test_comment -->
            data_test3.slcio
        </parameter>
```
**Before PR:**
```
LCIO Input Files:
data_test1.slcio
data_test2.slcio
```
**After PR:**
```
LCIO Input Files:
data_test1.slcio
data_test2.slcio
data_test3.slcio
```
___
#### Simple tests that don't change the behaviour
```
<parameter name="LCIOInputFiles" value="data_test1.slcio data_test2.slcio"/>
<parameter name="LCIOInputFiles" value="data_test1.slcio data_test2.slcio"></parameter>
<parameter name="LCIOInputFiles">data_test1.slcio data_test2.slcio</parameter>
<parameter name="LCIOInputFiles" default="filename.slcio" type="string"> data_test1.slcio data_test2.slcio</parameter>
```

**Before/After PR:**
```
. . .
LCIO Input Files:
data_test1.slcio
data_test2.slcio
. . .
```
___

Let me know if I should check other variations.

