### PR TITLE
Patch missing collections  

### DIFF
--- a/source/include/marlin/PatchCollections.h
+++ b/source/include/marlin/PatchCollections.h
@@ -1,0 +1,82 @@
+#ifndef PatchCollections_h
+#define PatchCollections_h 1
+
+#include "marlin/Processor.h"
+#include "marlin/EventModifier.h"
+#include "lcio.h"
+#include <string>
+#include <set>
+#include <map>  // pair
+
+using namespace lcio ;
+using namespace marlin ;
+
+namespace UTIL{
+  class CheckCollections ;
+}
+
+/** Patch events with empty collections that are not present in all events.
+ *  This could be useful, e.g. in context of conversion to EDM4hep, where every
+ *  collection needs to be in every event in a given file.
+ *
+ *  NB:  run this processor before any other processor that is processing events.
+ * 
+ * @param  PatchCollections:   pairs of: CollectionName  CollectionType
+ * 
+ * @author F. Gaede, DESY
+ * @date   Dec, 2022
+ */
+namespace marlin {
+
+  class PatchCollections : public Processor {
+
+    typedef std::set< std::pair< std::string, std::string > > SET ;
+
+  public:
+
+    virtual Processor*  newProcessor() { return new PatchCollections ; }
+
+    PatchCollections() ;
+
+    /** Called at the begin of the job before anything is read.
+     * Use to initialize the processor, e.g. book histograms.
+     */
+    virtual void init() ;
+
+    /** Called for every run.
+     */
+    virtual void processRunHeader( LCRunHeader* run ) ;
+
+    /** Called for every event - the working horse.
+     */
+    virtual void processEvent( LCEvent * evt ) ;
+
+    virtual void check( LCEvent * evt ) ;
+
+//    virtual void modifyEvent( LCEvent *evt ) ;
+
+    /** Called after data processing for clean up.
+     */
+    virtual void end() ;
+
+    virtual const std::string & name() const { return Processor::name() ; }
+
+
+  protected:
+
+    std::vector<std::string> _colList{};
+    SET _patchCols{};
+
+    int _nRun=-1;
+    int _nEvt=-1;
+    UTIL::CheckCollections* _colCheck ;
+
+
+  } ;
+
+} // namespace marlin
+
+#endif
+
+
+

--- a/source/include/marlin/PatchCollections.h
+++ b/source/include/marlin/PatchCollections.h
@@ -6,7 +6,8 @@
 #include "lcio.h"
 #include <string>
 #include <vector>
-#include <map>  // pair
+#include <utility>  // pair
+#include <memory>
 
 using namespace lcio ;
 using namespace marlin ;

--- a/source/include/marlin/PatchCollections.h
+++ b/source/include/marlin/PatchCollections.h
@@ -18,6 +18,9 @@ namespace UTIL{
 /** Patch events with empty collections that are not present in all events.
  *  This could be useful, e.g. in context of conversion to EDM4hep, where every
  *  collection needs to be in every event in a given file.
+ *  If @PatchCollections is not specified, all inputfiles of the current job are checked for
+ *  missing collections and these are then added to all events.
+ *
  *
  *  NB:  run this processor before any other processor that is processing events.
  * 

--- a/source/include/marlin/PatchCollections.h
+++ b/source/include/marlin/PatchCollections.h
@@ -18,12 +18,19 @@ namespace UTIL{
 /** Patch events with empty collections that are not present in all events.
  *  This could be useful, e.g. in context of conversion to EDM4hep, where every
  *  collection needs to be in every event in a given file.
- *  If @PatchCollections is not specified, all inputfiles of the current job are checked for
- *  missing collections and these are then added to all events.
+ *  There are two modes of how this can be used:
  *
+ *  If @ParseInputFiles is true  all inputfiles are parsed for missing collections on init() and
+ *                      then these are patched as needed in the processing - might cause some delay in program start
+ *                      Collections in  @PatchCollections are ignored in this case
+ *
+ *  If @ParseInputFiles is false, all users specified collections in @PatchCollections are patched as empty
+ *                      collections if needed - this will be faster, but requires the user to know which collections
+ *                      to patch (e.g. from the LCIO tool `check_missing_collections`)
  *
  *  NB:  run this processor before any other processor that is processing events.
  * 
+ * @param  ParseInputFiles:   if true, all inputfiles are parsed for missing collections on init
  * @param  PatchCollections:   pairs of: CollectionName  CollectionType
  * 
  * @author F. Gaede, DESY
@@ -67,13 +74,13 @@ namespace marlin {
 
   protected:
 
-    std::vector<std::string> _colList{};
+    StringVec _colList{};
     Vector _patchCols{};
+    bool _parseFiles = false ;
 
     int _nRun=-1;
     int _nEvt=-1;
     UTIL::CheckCollections* _colCheck = nullptr ;
-
 
   } ;
 

--- a/source/include/marlin/PatchCollections.h
+++ b/source/include/marlin/PatchCollections.h
@@ -5,7 +5,7 @@
 #include "marlin/EventModifier.h"
 #include "lcio.h"
 #include <string>
-#include <set>
+#include <vector>
 #include <map>  // pair
 
 using namespace lcio ;
@@ -33,7 +33,7 @@ namespace marlin {
 
   class PatchCollections : public Processor {
 
-    typedef std::set< std::pair< std::string, std::string > > SET ;
+    typedef std::vector< std::pair< std::string, std::string > > Vector;
 
   public:
 
@@ -68,11 +68,11 @@ namespace marlin {
   protected:
 
     std::vector<std::string> _colList{};
-    SET _patchCols{};
+    Vector _patchCols{};
 
     int _nRun=-1;
     int _nEvt=-1;
-    UTIL::CheckCollections* _colCheck ;
+    UTIL::CheckCollections* _colCheck = nullptr ;
 
 
   } ;

--- a/source/include/marlin/PatchCollections.h
+++ b/source/include/marlin/PatchCollections.h
@@ -80,7 +80,7 @@ namespace marlin {
 
     int _nRun=-1;
     int _nEvt=-1;
-    UTIL::CheckCollections* _colCheck = nullptr ;
+    std::unique_ptr<UTIL::CheckCollections> _colCheck{nullptr};
 
   } ;
 

--- a/source/src/PatchCollections.cc
+++ b/source/src/PatchCollections.cc
@@ -51,7 +51,7 @@ void PatchCollections::init() {
   _nRun = 0 ;
   _nEvt = 0 ;
   
-  _colCheck = new CheckCollections() ;
+  _colCheck = std::make_unique<CheckCollections>() ;
 
 
   if( ! _parseFiles ) { // ------ patch only user defined collections

--- a/source/src/PatchCollections.cc
+++ b/source/src/PatchCollections.cc
@@ -58,7 +58,7 @@ void PatchCollections::init() {
   if( nCols > 0 ) { 
     
     for( unsigned i=0 ; i < nCols ; i+=2 ) {
-      _patchCols.insert( std::make_pair( _colList[i] , _colList[ i+1 ] ) ) ;
+      _patchCols.push_back( { _colList[i] , _colList[ i+1 ] } ) ;
     }
 
   } else {
@@ -78,7 +78,8 @@ void PatchCollections::init() {
 
     _colCheck->checkFiles( inFiles ) ;
 
-    _patchCols.merge( _colCheck->getMissingCollections() ) ;
+    auto mcols =  _colCheck->getMissingCollections() ;
+    std::copy( mcols.begin() , mcols.end() , std::back_inserter( _patchCols ) ) ;
     
     streamlog_out( MESSAGE ) << "   ... done " << std::endl  ;
   } 

--- a/source/src/PatchCollections.cc
+++ b/source/src/PatchCollections.cc
@@ -135,7 +135,6 @@ void PatchCollections::check( LCEvent *  ) {
 
 void PatchCollections::end(){ 
 
-  delete _colCheck ;  
 //   std::cout << "PatchCollections::end()  " << name() 
 // 	    << " processed " << _nEvt << " events in " << _nRun << " runs "
 // 	    << std::endl ;

--- a/source/src/PatchCollections.cc
+++ b/source/src/PatchCollections.cc
@@ -1,0 +1,139 @@
+#include "marlin/PatchCollections.h"
+#include "marlin/Global.h"
+//#include "marlin/StringParameters.h"
+
+#include "UTIL/CheckCollections.h"
+
+#include <iostream>
+
+// ----- include for verbosity dependend logging ---------
+#include "marlin/VerbosityLevels.h"
+
+
+using namespace lcio ;
+using namespace marlin ;
+
+
+PatchCollections aPatchCollections ;
+
+
+PatchCollections::PatchCollections() : Processor("PatchCollections") {
+  
+  // modify processor description
+  _description = "PatchCollections adds missing collections in 'PatchCollections' to the event - or all missing in inut files (if PatchCollections not given)" ;
+  
+  std::vector<std::string> colsExample ;
+  // colsExample.push_back( "BcalCollection" );
+  // colsExample.push_back( "SimCalorimeterHit" );
+  
+  
+  registerProcessorParameter( "PatchCollections" , 
+			      "list of collections to patch  - pairs of CollectionName CollectionType"  ,
+			      _colList ,
+			      colsExample ) ;
+  _nEvt = -1;
+  _nRun = -1;  
+}
+
+
+void PatchCollections::init() { 
+  
+  // usually a good idea to
+  printParameters() ;
+  
+  _nRun = 0 ;
+  _nEvt = 0 ;
+  
+  _colCheck = new CheckCollections() ;
+
+  
+  unsigned nCols = _colList.size() ;
+  
+  
+  if( nCols % 2 ){
+    throw Exception("Parameter PatchCollections needs to have pairs of 'name type'") ;
+  }
+
+
+  if( nCols > 0 ) { 
+    
+    for( unsigned i=0 ; i < nCols ; i+=2 ) {
+      _patchCols.insert( std::make_pair( _colList[i] , _colList[ i+1 ] ) ) ;
+    }
+
+  } else {
+
+    streamlog_out( MESSAGE ) << " no patch collections defined in steering - "
+			     << " will check all inputfiles for missing collections : "
+			     << std::endl ;
+
+    StringVec inFiles ;
+    Global::parameters->getStringVals("LCIOInputFiles" , inFiles ) ;
+
+    for(auto fn : inFiles ){
+      streamlog_out( MESSAGE ) << "  " << fn << std::endl ;
+    }
+
+    streamlog_out( MESSAGE ) << "   ... reading .. "  ;
+
+    _colCheck->checkFiles( inFiles ) ;
+
+    _patchCols.merge( _colCheck->getMissingCollections() ) ;
+    
+    streamlog_out( MESSAGE ) << "   ... done " << std::endl  ;
+  } 
+
+  
+  streamlog_out( MESSAGE ) << " will patch the following collections to all events where they are missing : " << std::endl ;
+  
+  for( auto c : _patchCols ){
+
+    streamlog_out( MESSAGE ) << "   " <<   c.first << "   " << c.second << std ::endl ;
+  }
+  
+  _colCheck->addPatchCollections( _patchCols ) ;
+
+
+}
+
+void PatchCollections::processRunHeader( LCRunHeader* ) { 
+  
+  _nRun++ ;
+} 
+
+
+// void PatchCollections::modifyEvent( LCEvent *evt ) {
+//   processEvent( evt );
+// }
+
+void PatchCollections::processEvent( LCEvent * evt ) { 
+
+
+  //-- note: this will not be printed if compiled w/o MARLINDEBUG=1 !
+
+  streamlog_out(DEBUG) << "   processing event: " << evt->getEventNumber() 
+		       << "   in run:  " << evt->getRunNumber() 
+		       << std::endl ;
+
+
+  _colCheck->patchCollections( evt ) ;
+
+  _nEvt ++ ;
+}
+
+
+
+void PatchCollections::check( LCEvent *  ) { 
+  // nothing to check here - could be used to fill checkplots in reconstruction processor
+}
+
+
+void PatchCollections::end(){ 
+
+  delete _colCheck ;  
+//   std::cout << "PatchCollections::end()  " << name() 
+// 	    << " processed " << _nEvt << " events in " << _nRun << " runs "
+// 	    << std::endl ;
+
+}
+


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a simple processor `PatchCollections` that can patch missing collections in LCIO events by adding empty collections to these events
-  needs https://github.com/iLCSoft/LCIO/pull/158

ENDRELEASENOTES