### PR TITLE
Fix compiler warnings and change `LCIO_LIBRARIES`

### DIFF
--- a/source/include/marlin/CCProcessor.h
+++ b/source/include/marlin/CCProcessor.h
@@ -169,8 +169,8 @@ namespace marlin {
     std::shared_ptr<StringParameters> _param;	    // parameters from processor
     Processor* _proc;		    // associated Marlin processor
  
-    const StringVec _error_desc{ "Processor has no Parameters", "Processor not available!", "Some Collections have Errors"}; // error descriptions for all processors
-    StringVec _errors{};	    // list of errors found in a processor
+    const EVENT::StringVec _error_desc{ "Processor has no Parameters", "Processor not available!", "Some Collections have Errors"}; // error descriptions for all processors
+    EVENT::StringVec _errors{};	    // list of errors found in a processor
 
     sSet _conditions;		    // processor's conditions
   

--- a/source/include/marlin/CMProcessor.h
+++ b/source/include/marlin/CMProcessor.h
@@ -68,7 +68,7 @@ namespace marlin{
 	bool isInstalled( const std::string& type );
 
 	//utility function to tokenize strings
-	void tokenize( const std::string str, StringVec& tokens, const std::string& delimiters = " " );
+        void tokenize( const std::string str, EVENT::StringVec& tokens, const std::string& delimiters = " " );
 
     private:
 	// Constructor

--- a/source/include/marlin/ConditionsProcessor.h
+++ b/source/include/marlin/ConditionsProcessor.h
@@ -15,8 +15,6 @@ namespace lccd{
     class IConditionsChangeListener;
 }
 
-using namespace lcio ;
-
 namespace marlin{
 
 
@@ -73,7 +71,7 @@ class ConditionsProcessor : public Processor {
   
   /** Updates all registered conditions handlers and adds the data to the event.
    */
-  virtual void processEvent( LCEvent * evt ) ; 
+  virtual void processEvent( EVENT::LCEvent * evt ) ; 
   
   
 //   virtual void check( LCEvent * evt ) ; 
@@ -88,19 +86,19 @@ class ConditionsProcessor : public Processor {
   std::string _dbInit="";
 
   /** initialization of SimpleFileHandlers */
-  StringVec _simpleHandlerInit{};
+  EVENT::StringVec _simpleHandlerInit{};
 
   /** initialization of DBCondHandlers */
-  StringVec _dbcondHandlerInit{};
+  EVENT::StringVec _dbcondHandlerInit{};
 
   /** initialization of DBFileHandlers */
-  StringVec _dbfileHandlerInit{};
+  EVENT::StringVec _dbfileHandlerInit{};
 
   /** initialization of DataFileHandlers */
-  StringVec _datafileHandlerInit{};
+  EVENT::StringVec _datafileHandlerInit{};
 
   /** the names of all handlers */
-  StringVec _condHandlerNames{};
+  EVENT::StringVec _condHandlerNames{};
 
   int _nRun=-1;
   int _nEvt=-1;

--- a/source/include/marlin/DataSourceProcessor.h
+++ b/source/include/marlin/DataSourceProcessor.h
@@ -3,8 +3,6 @@
 
 #include "marlin/Processor.h"
 
-using namespace lcio ;
-
 
 namespace marlin{
   

--- a/source/include/marlin/EventSelector.h
+++ b/source/include/marlin/EventSelector.h
@@ -8,9 +8,6 @@
 #include <set>
 #include <map>  // pair
 
-using namespace lcio ;
-using namespace marlin ;
-
 
 /** Simple event selector processor. Returns true if the given event 
  *  was specified in the EvenList parameter.
@@ -42,15 +39,15 @@ namespace marlin {
 
     /** Called for every run.
      */
-    virtual void processRunHeader( LCRunHeader* run ) ;
+    virtual void processRunHeader( EVENT::LCRunHeader* run ) ;
 
     /** Called for every event - the working horse.
      */
-    virtual void processEvent( LCEvent * evt ) ;
+    virtual void processEvent( EVENT::LCEvent * evt ) ;
 
-    virtual void check( LCEvent * evt ) ;
+    virtual void check( EVENT::LCEvent * evt ) ;
 
-    virtual void modifyEvent( LCEvent *evt ) ;
+    virtual void modifyEvent( EVENT::LCEvent *evt ) ;
 
     /** Called after data processing for clean up.
      */
@@ -63,7 +60,7 @@ namespace marlin {
 
     /** Input collection name.
      */
-    IntVec _evtList{};
+    EVENT::IntVec _evtList{};
     SET _evtSet{};
 
     int _nRun=-1;

--- a/source/include/marlin/Exceptions.h
+++ b/source/include/marlin/Exceptions.h
@@ -18,7 +18,7 @@ namespace marlin{
   protected:
     ParseException() {  /*no_op*/ ; } 
   public: 
-    virtual ~ParseException() throw() { /*no_op*/; } 
+    virtual ~ParseException() noexcept { /*no_op*/; } 
 
     ParseException( std::string text ){
       message = "marlin::ParseException: " + text ;
@@ -40,7 +40,7 @@ namespace marlin{
     SkipEventException(const Processor* proc){
       message = proc->name()  ;
     }
-    virtual ~SkipEventException() throw() { /*no_op*/; } 
+    virtual ~SkipEventException() noexcept { /*no_op*/; } 
 
   }; 
 
@@ -58,7 +58,7 @@ namespace marlin{
     StopProcessingException(const Processor* proc){
       message = proc->name()  ;
     }
-    virtual ~StopProcessingException() throw() { /*no_op*/; } 
+    virtual ~StopProcessingException() noexcept { /*no_op*/; } 
 
   }; 
 
@@ -76,7 +76,7 @@ namespace marlin{
     RewindDataFilesException(const Processor* proc){
       message = proc->name()  ;
     }
-    virtual ~RewindDataFilesException() throw() { /*no_op*/; } 
+    virtual ~RewindDataFilesException() noexcept { /*no_op*/; } 
 
   }; 
 

--- a/source/include/marlin/Exceptions.h
+++ b/source/include/marlin/Exceptions.h
@@ -19,6 +19,7 @@ namespace marlin{
     ParseException() {  /*no_op*/ ; } 
   public: 
     virtual ~ParseException() noexcept { /*no_op*/; } 
+    ParseException( const ParseException& e ) = default ;
 
     ParseException( std::string text ){
       message = "marlin::ParseException: " + text ;

--- a/source/include/marlin/IFourVectorSmearer.h
+++ b/source/include/marlin/IFourVectorSmearer.h
@@ -8,7 +8,6 @@
 #include "CLHEP/Vector/LorentzVector.h"
 
 namespace CLHEP{}    // declare namespace CLHEP for backward compatibility
-using namespace CLHEP ;
 
 
 namespace marlin{
@@ -29,7 +28,7 @@ namespace marlin{
     
     /** Smears the given four vector 
      */ 
-    virtual HepLorentzVector smearedFourVector( const HepLorentzVector& v, int pdgCode ) = 0 ;
+    virtual CLHEP::HepLorentzVector smearedFourVector( const CLHEP::HepLorentzVector& v, int pdgCode ) = 0 ;
     
   } ;
   

--- a/source/include/marlin/LCIOOutputProcessor.h
+++ b/source/include/marlin/LCIOOutputProcessor.h
@@ -6,8 +6,6 @@
 #include "IO/LCWriter.h"
 
 
-using namespace lcio ;
-
 namespace IMPL{
   class LCCollectionVec ;
 }
@@ -47,7 +45,7 @@ namespace marlin{
    */
   class LCIOOutputProcessor : public Processor {
   
-    typedef std::vector< LCCollectionVec* > SubSetVec ;
+    typedef std::vector< lcio::LCCollectionVec* > SubSetVec ;
 
 
   public:  
@@ -70,11 +68,11 @@ namespace marlin{
 
     /** Write every run header.
      */
-    virtual void processRunHeader( LCRunHeader* run) ;
+    virtual void processRunHeader( EVENT::LCRunHeader* run) ;
 
     /** Write every event.
      */
-    virtual void processEvent( LCEvent * evt ) ; 
+    virtual void processEvent( EVENT::LCEvent * evt ) ; 
 
     /** Close outputfile.
      */
@@ -83,7 +81,7 @@ namespace marlin{
     /** Drops the collections specified in the steering file parameters DropCollectionNames and 
      *  DropCollectionTypes. 
      */
-    void dropCollections( LCEvent * evt ) ;
+    void dropCollections( EVENT::LCEvent * evt ) ;
 
 
   protected:
@@ -91,16 +89,16 @@ namespace marlin{
     std::string _lcioOutputFile="";
     std::string _lcioWriteMode="";
 
-    StringVec _dropCollectionNames{};
-    StringVec _dropCollectionTypes{};
-    StringVec _keepCollectionNames{};
-    StringVec _fullSubsetCollections{};
+    EVENT::StringVec _dropCollectionNames{};
+    EVENT::StringVec _dropCollectionTypes{};
+    EVENT::StringVec _keepCollectionNames{};
+    EVENT::StringVec _fullSubsetCollections{};
 
     int _splitFileSizekB=1992294;
 
     SubSetVec _subSets{};
 
-    LCWriter* _lcWrt=NULL;
+    lcio::LCWriter* _lcWrt=NULL;
     int _nRun=-1;
     int _nEvt=-1;
     int _compressionLevel{6};

--- a/source/include/marlin/LogicalExpressions.h
+++ b/source/include/marlin/LogicalExpressions.h
@@ -127,9 +127,6 @@ namespace marlin{
       _last = c ;
     }
 
-    ~Tokenizer(){
-    }
-    
     std::vector<Expression> & result()  { 
       
       return _tokens ; 

--- a/source/include/marlin/MarlinSteerCheck.h
+++ b/source/include/marlin/MarlinSteerCheck.h
@@ -101,7 +101,7 @@ namespace marlin {
     ColVec& getLCIOCols() const;
     
     /** Returns the names of the LCIO files found in the global section*/
-    StringVec& getLCIOFiles(){ return _lcioFiles; }
+    EVENT::StringVec& getLCIOFiles(){ return _lcioFiles; }
 
     /** Returns a list of all available Collections for a given type, name and processor (to use in a ComboBox) */
     sSet& getColsSet( const std::string& type, const std::string& name, CCProcessor* proc );
@@ -227,7 +227,7 @@ namespace marlin {
     ProcVec _aProc{};			//active processors
     ProcVec _iProc{};			//inactive processors
     sColVecMap _lcioCols{};		//LCIO collections
-    StringVec _lcioFiles{};		//LCIO filenames
+    EVENT::StringVec _lcioFiles{};		//LCIO filenames
     
     sSet _colValues{};			//all available collection values for a given type (use in ComboBox)
 

--- a/source/include/marlin/MemoryMonitor.h
+++ b/source/include/marlin/MemoryMonitor.h
@@ -8,9 +8,6 @@
 #include "stdio.h"
 #include "string.h"
 
-using namespace lcio ;
-using namespace marlin ;
-
 
 /** MemoryMonitor is a memory monitoring application for Marlin
  *  <h4>Input - Prerequisites</h4>
@@ -24,7 +21,7 @@ using namespace marlin ;
  * @author N. Nikiforou, CERN,
  */
 
-class MemoryMonitor : public Processor {
+class MemoryMonitor : public marlin::Processor {
 		
 public:
 	
@@ -36,13 +33,13 @@ public:
 	virtual void init() ;
 	
 	// Called at the beginning of every run
-	virtual void processRunHeader( LCRunHeader* run ) ;
+       virtual void processRunHeader( EVENT::LCRunHeader* run ) ;
 	
 	// Run over each event - the main algorithm
-	virtual void processEvent( LCEvent * evt ) ;
+        virtual void processEvent( EVENT::LCEvent * evt ) ;
 	
   // Run at the end of each event
-	virtual void check( LCEvent * evt ) ;
+        virtual void check( EVENT::LCEvent * evt ) ;
 	
 	// Called at the very end for cleanup, histogram saving, etc.
 	virtual void end() ;

--- a/source/include/marlin/Parser.h
+++ b/source/include/marlin/Parser.h
@@ -113,9 +113,6 @@ class LCTokenizer{
 
   } 
 
-  ~LCTokenizer(){
-  }
-  
   std::vector<std::string> & result()  { 
     
     return _tokens ; 

--- a/source/include/marlin/PatchCollections.h
+++ b/source/include/marlin/PatchCollections.h
@@ -9,9 +9,6 @@
 #include <utility>  // pair
 #include <memory>
 
-using namespace lcio ;
-using namespace marlin ;
-
 namespace UTIL{
   class CheckCollections ;
 }
@@ -56,13 +53,13 @@ namespace marlin {
 
     /** Called for every run.
      */
-    virtual void processRunHeader( LCRunHeader* run ) ;
+    virtual void processRunHeader( EVENT::LCRunHeader* run ) ;
 
     /** Called for every event - the working horse.
      */
-    virtual void processEvent( LCEvent * evt ) ;
+    virtual void processEvent( EVENT::LCEvent * evt ) ;
 
-    virtual void check( LCEvent * evt ) ;
+    virtual void check( EVENT::LCEvent * evt ) ;
 
 //    virtual void modifyEvent( LCEvent *evt ) ;
 
@@ -75,7 +72,7 @@ namespace marlin {
 
   protected:
 
-    StringVec _colList{};
+    EVENT::StringVec _colList{};
     Vector _patchCols{};
     bool _parseFiles = false ;
 

--- a/source/include/marlin/Processor.h
+++ b/source/include/marlin/Processor.h
@@ -32,8 +32,6 @@
 
 class MarlinProcessorWrapper;
 
-using namespace lcio ;
-
 
 namespace marlin{
 /** Helper class that gives an external processor manager access to private
@@ -117,17 +115,17 @@ struct ExternalProcessorMgrAccessor {
     /** Called for every run, e.g. overwrite to initialize run dependent 
      *  histograms.
      */
-    virtual void processRunHeader( LCRunHeader* ) { } 
+    virtual void processRunHeader( EVENT::LCRunHeader* ) { } 
 
     /** Called for every event - the working horse. 
      */
-    virtual void processEvent( LCEvent * ) { }
+    virtual void processEvent( EVENT::LCEvent * ) { }
 
     /** Called for every event - right after processEvent()
      *  has been called for  this processor.
      *  Use to check processing and/or produce check plots.
      */
-    virtual void check( LCEvent* ) { }
+    virtual void check( EVENT::LCEvent* ) { }
 
     /**
      * Public overload of setFirstEvent for use in external processor managers
@@ -316,8 +314,8 @@ struct ExternalProcessorMgrAccessor {
     void registerInputCollections(const std::string& collectionType,
 				  const std::string& parameterName, 
 				  const std::string& parameterDescription,
-				  StringVec& parameter,
-				  const StringVec& defaultVal,
+				  EVENT::StringVec& parameter,
+				  const EVENT::StringVec& defaultVal,
 				  int setSize=0 ) {
       
       setLCIOInType( parameterName , collectionType ) ;

--- a/source/include/marlin/ProcessorEventSeeder.h
+++ b/source/include/marlin/ProcessorEventSeeder.h
@@ -6,8 +6,6 @@
 #include <vector>
 #include <map>
 
-using namespace lcio ;
-
 namespace marlin{
 
   class ProcessorMgr;  
@@ -79,7 +77,7 @@ namespace marlin{
     /** Create new set of seeds for registered Processors for the given event.
      *  This method should only be called from ProcessorMgr::processEvent
      */
-    void refreshSeeds( LCEvent * evt ) ;
+    void refreshSeeds( EVENT::LCEvent * evt ) ;
     
     ProcessorEventSeeder(const ProcessorEventSeeder&);	// prevent copying
     ProcessorEventSeeder& operator=(const ProcessorEventSeeder&); // prevent assignment

--- a/source/include/marlin/ProcessorMgr.h
+++ b/source/include/marlin/ProcessorMgr.h
@@ -16,8 +16,6 @@
 #include <set>
 #include <list>
 
-using namespace lcio ;
-
 namespace marlin{
 
   class ProcessorEventSeeder;
@@ -33,7 +31,7 @@ typedef std::map< const std::string , int > SkippedEventMap ;
  *  @author F. Gaede, DESY
  *  @version $Id: ProcessorMgr.h,v 1.16 2007-08-13 10:38:39 gaede Exp $ 
  */
-class ProcessorMgr : public LCRunListener, public LCEventListener {
+  class ProcessorMgr : public IO::LCRunListener, public IO::LCEventListener {
 
 friend class  Processor ;   
 friend class  CMProcessor ;   
@@ -85,13 +83,13 @@ public:
   void dumpRegisteredProcessorsXML() ;
   
   virtual void init() ;
-  virtual void processRunHeader( LCRunHeader* ) ;   
-  virtual void processEvent( LCEvent* ) ;
+  virtual void processRunHeader( EVENT::LCRunHeader* ) ;   
+  virtual void processEvent( EVENT::LCEvent* ) ;
   virtual void end() ;
   
   
-  virtual void modifyRunHeader( LCRunHeader*) ; 
-  virtual void modifyEvent( LCEvent *) ; 
+  virtual void modifyRunHeader( EVENT::LCRunHeader*) ; 
+  virtual void modifyEvent( EVENT::LCEvent *) ; 
 
   /** Calls readDataSource() for all Processors of type DataSourceProcessor.
    */

--- a/source/include/marlin/ProcessorParameter.h
+++ b/source/include/marlin/ProcessorParameter.h
@@ -13,8 +13,6 @@
 // typedef std::map< std::string ,  std::vector< std::string > >  ParametersMap ;
 
 
-using namespace lcio ;
-
 namespace marlin{
   
   /** Class that holds a steering variable for a marlin processor - automatically created by
@@ -148,9 +146,9 @@ namespace marlin{
       // return typeid( _parameter ).name() ; } 
 
       // make this human readable
-      if     ( typeid( _parameter ) == typeid( IntVec    )) return "IntVec" ;
-      else if( typeid( _parameter ) == typeid( FloatVec  )) return "FloatVec" ;
-      else if( typeid( _parameter ) == typeid( StringVec )) return "StringVec" ;
+      if     ( typeid( _parameter ) == typeid( EVENT::IntVec    )) return "IntVec" ;
+      else if( typeid( _parameter ) == typeid( EVENT::FloatVec  )) return "FloatVec" ;
+      else if( typeid( _parameter ) == typeid( EVENT::StringVec )) return "StringVec" ;
       else if( typeid( _parameter ) == typeid( int   )) return "int" ;
       else if( typeid( _parameter ) == typeid( float )) return "float" ;
       else if( typeid( _parameter ) == typeid( double )) return "double" ;

--- a/source/include/marlin/SimpleClusterSmearer.h
+++ b/source/include/marlin/SimpleClusterSmearer.h
@@ -61,7 +61,7 @@ namespace marlin{
      *  polar angle of the cluster. Returns a vector with all elements 0. if
      *  no resolution is defined.
      */ 
-    virtual HepLorentzVector smearedFourVector( const HepLorentzVector& v, int pdgCode ) ;
+    virtual CLHEP::HepLorentzVector smearedFourVector( const CLHEP::HepLorentzVector& v, int pdgCode ) ;
     
   protected:
 

--- a/source/include/marlin/SimpleFastMCProcessor.h
+++ b/source/include/marlin/SimpleFastMCProcessor.h
@@ -9,8 +9,6 @@
 
 
 
-using namespace lcio ;
-
 namespace marlin{
  
 
@@ -85,15 +83,15 @@ namespace marlin{
     
     /** Called for every run.
      */
-    virtual void processRunHeader( LCRunHeader* run ) ;
+    virtual void processRunHeader( EVENT::LCRunHeader* run ) ;
     
     /** Updates all registered conditions handlers and adds the data to the event.
      */
-    virtual void processEvent( LCEvent * evt ) ; 
+    virtual void processEvent( EVENT::LCEvent * evt ) ; 
     
     /** Creates some checkplots.
      */
-    virtual void check( LCEvent * evt ) ; 
+    virtual void check( EVENT::LCEvent * evt ) ; 
     
     /** Called after data processing for clean up.
      */
@@ -113,13 +111,13 @@ namespace marlin{
     float _momentumCut=0.0;
 
     /** Resolutions of charged particles */
-    FloatVec _initChargedRes{};
+    EVENT::FloatVec _initChargedRes{};
 
     /** Resolutions of photons */
-    FloatVec _initPhotonRes{};
+    EVENT::FloatVec _initPhotonRes{};
 
     /** Resolutions of photons */
-    FloatVec _initNeutralHadronRes{};
+    EVENT::FloatVec _initNeutralHadronRes{};
 
     /** The particle factory */
     IRecoParticleFactory* _factory=NULL;

--- a/source/include/marlin/SimpleTrackSmearer.h
+++ b/source/include/marlin/SimpleTrackSmearer.h
@@ -64,7 +64,7 @@ namespace marlin{
      *  polar angle of the track. Returns a vector with all elements 0. if
      *  no resolution is defined.
      */ 
-    virtual HepLorentzVector smearedFourVector( const HepLorentzVector& v, int pdgCode ) ;
+    virtual CLHEP::HepLorentzVector smearedFourVector( const CLHEP::HepLorentzVector& v, int pdgCode ) ;
     
   protected:
 

--- a/source/include/marlin/Statusmonitor.h
+++ b/source/include/marlin/Statusmonitor.h
@@ -5,7 +5,6 @@
 #include "lcio.h"
 #include <string>
 
-using namespace lcio ;
 using namespace marlin ;
 
   /** Simple processor for writing out a status message every n-th event.
@@ -32,14 +31,14 @@ class Statusmonitor : public Processor {
   
   /** Called for every run.
    */
-  virtual void processRunHeader( LCRunHeader* run ) ;
+  virtual void processRunHeader( EVENT::LCRunHeader* run ) ;
   
   /** Called for every event - the working horse.
    */
-  virtual void processEvent( LCEvent * evt ) ; 
+  virtual void processEvent( EVENT::LCEvent * evt ) ; 
   
   
-  virtual void check( LCEvent * evt ) ; 
+  virtual void check( EVENT::LCEvent * evt ) ; 
   
   
   /** Called after data processing for clean up.

--- a/source/include/marlin/Statusmonitor.h
+++ b/source/include/marlin/Statusmonitor.h
@@ -5,8 +5,6 @@
 #include "lcio.h"
 #include <string>
 
-using namespace marlin ;
-
   /** Simple processor for writing out a status message every n-th event.
    *
    *  <h4>Input - Prerequisites</h4>
@@ -18,7 +16,7 @@ using namespace marlin ;
    * @author A.Sailer CERN
    * @version $Id:$
    */
-class Statusmonitor : public Processor {
+class Statusmonitor : public marlin::Processor {
   
  public:
   

--- a/source/include/marlin/StdHepReader.h
+++ b/source/include/marlin/StdHepReader.h
@@ -3,8 +3,6 @@
 
 #include "marlin/DataSourceProcessor.h"
 
-using namespace lcio ;
-
 
 namespace marlin{
   

--- a/source/include/marlin/StringParameters.h
+++ b/source/include/marlin/StringParameters.h
@@ -21,8 +21,6 @@
 typedef std::map< std::string ,  std::vector< std::string > >  ParametersMap ;
 
 
-using namespace lcio ;
-
 namespace marlin{
 
 /** Simple parameters class for Marlin.
@@ -51,11 +49,11 @@ public:
   float getFloatVal( const std::string& key ) ;
   const std::string& getStringVal( const std::string& key ) ;
 
-  IntVec& getIntVals( const std::string& key ,  IntVec& intVec ) ;
-  FloatVec& getFloatVals( const std::string& key ,  FloatVec& floatVec ) ;
-  StringVec & getStringVals( const std::string& key  , StringVec & stringVec ) ;
+  EVENT::IntVec& getIntVals( const std::string& key ,    EVENT::IntVec& intVec ) ;
+  EVENT::FloatVec& getFloatVals( const std::string& key ,    EVENT::FloatVec& floatVec ) ;
+  EVENT::StringVec & getStringVals( const std::string& key  ,   EVENT::StringVec & stringVec ) ;
 
-  StringVec& getStringKeys( StringVec& stringVec );
+  EVENT::StringVec& getStringKeys(   EVENT::StringVec& stringVec );
   
   virtual ~StringParameters() ; 
   

--- a/source/include/marlin/TestProcessor.h
+++ b/source/include/marlin/TestProcessor.h
@@ -4,8 +4,6 @@
 #include "Processor.h"
 #include "lcio.h"
 
-using namespace lcio ;
-
 
 namespace marlin {
   
@@ -39,14 +37,14 @@ namespace marlin {
     
     /** Called for every run.
      */
-    virtual void processRunHeader( LCRunHeader* run ) ;
+    virtual void processRunHeader( EVENT::LCRunHeader* run ) ;
     
     /** Called for every event - the working horse.
      */
-    virtual void processEvent( LCEvent * evt ) ; 
+    virtual void processEvent( EVENT::LCEvent * evt ) ; 
     
     
-    virtual void check( LCEvent * evt ) ; 
+    virtual void check( EVENT::LCEvent * evt ) ; 
     
     
     /** Called after data processing for clean up.

--- a/source/include/marlin/XMLParser.h
+++ b/source/include/marlin/XMLParser.h
@@ -137,9 +137,6 @@ namespace marlin{
 
       } 
 
-      ~LCTokenizer(){
-      }
-  
       std::vector<std::string> & result()  { 
     
 	return _tokens ; 

--- a/source/src/CCProcessor.cc
+++ b/source/src/CCProcessor.cc
@@ -4,6 +4,7 @@
 #include "marlin/ProcessorMgr.h"
 
 using namespace std;
+using namespace lcio;
 
 namespace marlin{
 

--- a/source/src/CMProcessor.cc
+++ b/source/src/CMProcessor.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 
 using namespace std;
+using namespace lcio;
 
 namespace marlin{
     

--- a/source/src/LCIOOutputProcessor.cc
+++ b/source/src/LCIOOutputProcessor.cc
@@ -16,6 +16,8 @@
 #include <algorithm>
 #include <bitset>
 
+using namespace lcio ;
+
 namespace marlin{
   
   LCIOOutputProcessor anLCIOOutputProcessor ;

--- a/source/src/MarlinSteerCheck.cc
+++ b/source/src/MarlinSteerCheck.cc
@@ -25,6 +25,7 @@
 #include <algorithm>
 
 using namespace std;
+using namespace lcio;
 
 namespace marlin{
 

--- a/source/src/ProcessorEventSeeder.cc
+++ b/source/src/ProcessorEventSeeder.cc
@@ -8,6 +8,8 @@
 #include <limits>
 #include <algorithm>
 
+using namespace lcio ;
+
 namespace marlin{
 
 

--- a/source/src/ProcessorMgr.cc
+++ b/source/src/ProcessorMgr.cc
@@ -16,6 +16,8 @@
 
 #include <time.h>
 
+using namespace lcio ;
+
 namespace marlin{
 
     ProcessorMgr* ProcessorMgr::_me = 0 ;

--- a/source/src/ProcessorParameter.cc
+++ b/source/src/ProcessorParameter.cc
@@ -1,6 +1,8 @@
 #include "marlin/ProcessorParameter.h"
 #include <algorithm>
 
+using namespace lcio ;
+
 namespace marlin {
 
 //   const std::string ProcessorParameter::type() { 

--- a/source/src/SimpleClusterSmearer.cc
+++ b/source/src/SimpleClusterSmearer.cc
@@ -10,6 +10,7 @@
 
 // #include "CLHEP/Vector/ThreeVector.h"
 
+using namespace CLHEP ;
 
 namespace marlin{
 

--- a/source/src/SimpleFastMCProcessor.cc
+++ b/source/src/SimpleFastMCProcessor.cc
@@ -35,6 +35,7 @@
 #include <cmath>
 
 using namespace lcio ;
+using namespace CLHEP ;
 
 
 namespace marlin{
@@ -196,7 +197,9 @@ namespace marlin{
 
 
   void SimpleFastMCProcessor::check( LCEvent * evt ) { 
-    
+
+    // silence possible warning about unused parameter without AIDA
+    (void)evt ;
     
 #ifdef MARLIN_AIDA
     

--- a/source/src/SimpleParticleFactory.cc
+++ b/source/src/SimpleParticleFactory.cc
@@ -27,6 +27,7 @@
 #include "UTIL/LCFourVector.h"
 
 using namespace lcio ;
+using namespace CLHEP ;
 
 
 namespace marlin{

--- a/source/src/StdHepReader.cc
+++ b/source/src/StdHepReader.cc
@@ -10,6 +10,8 @@
 #include "UTIL/LCTOOLS.h"
 
 
+using namespace lcio ;
+
 namespace marlin{
 
 

--- a/source/src/StringParameters.cc
+++ b/source/src/StringParameters.cc
@@ -5,6 +5,8 @@
 #include <exception>
 #include <iomanip>
 
+using namespace lcio ;
+
 namespace marlin{
 
 StringParameters::StringParameters(){

--- a/source/src/TestProcessor.cc
+++ b/source/src/TestProcessor.cc
@@ -8,6 +8,8 @@
 
 #include "streamlog/streamlog.h"
 
+using namespace lcio ;
+
 namespace marlin{
 
 

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -195,8 +195,8 @@ namespace marlin{
         // count processors with collection type information in order to generate warning
         // about old files or missing type info
         std::pair<unsigned,unsigned> typeCount ;
-        unsigned procCount(0) ; 
-        unsigned typedProcCount(0) ;
+        // unsigned procCount(0) ;
+        // unsigned typedProcCount(0) ;
 
         // use this variable to check for duplicate processor definitions
         procList.clear();
@@ -233,13 +233,13 @@ namespace marlin{
             parametersFromNode( section , constants, &typeCount ) ;
 
             if( typeCount.first > currentCount.first || typeCount.second > currentCount.second ){
-                ++typedProcCount ; // at least one type info attribute found in processor
+                // ++typedProcCount ; // at least one type info attribute found in processor
             }
             //       else { 
             // 	std::cout << " -- processor w/o type info : " << name << std::endl ;
             //       }
 
-            ++procCount ;
+            // ++procCount ;
         }
 
         globalParameters->add( availableProcs )  ;

--- a/test/marlintest/include/TestEventModifier.h
+++ b/test/marlintest/include/TestEventModifier.h
@@ -8,10 +8,6 @@
 #include <string>
 
 
-using namespace lcio ;
-using namespace marlin ;
-
-
 /**  Example processor for marlin.
  * 
  *  If compiled with MARLIN_USE_AIDA 
@@ -29,7 +25,7 @@ using namespace marlin ;
  * @version $Id: TestEventModifier.h,v 1.4 2005-10-11 12:57:39 gaede Exp $ 
  */
 
-class TestEventModifier : public Processor, public EventModifier {
+class TestEventModifier : public marlin::Processor, public marlin::EventModifier {
   
  public:
   
@@ -56,14 +52,14 @@ class TestEventModifier : public Processor, public EventModifier {
   
   /** Called for every run.
    */
-  virtual void processRunHeader( LCRunHeader* run ) ;
+  virtual void processRunHeader( EVENT::LCRunHeader* run ) ;
   
   /** Called for every event - the working horse.
    */
-  virtual void processEvent( LCEvent * evt ) ; 
+  virtual void processEvent( EVENT::LCEvent * evt ) ; 
   
   
-  virtual void check( LCEvent * evt ) ; 
+  virtual void check( EVENT::LCEvent * evt ) ; 
   
   
   /** Called after data processing for clean up.

--- a/test/marlintest/include/TestProcessorEventSeeder.h
+++ b/test/marlintest/include/TestProcessorEventSeeder.h
@@ -10,9 +10,6 @@
 #include <map>
 #include <vector>
 
-using namespace lcio ;
-using namespace marlin ;
-
 
 /**  test processor for testing the uniquie event seeding functionality of the ProcessorEventSeeder service in Marlin.
  * 
@@ -20,7 +17,7 @@ using namespace marlin ;
  * @author S. J. Aplin, DESY
  */
 
-class TestProcessorEventSeeder : public Processor {
+class TestProcessorEventSeeder : public marlin::Processor {
   
  public:
   
@@ -42,14 +39,14 @@ class TestProcessorEventSeeder : public Processor {
   
   /** Called for every run.
    */
-  virtual void processRunHeader( LCRunHeader* run ) ;
+  virtual void processRunHeader( EVENT::LCRunHeader* run ) ;
   
   /** Called for every event - the working horse.
    */
-  virtual void processEvent( LCEvent * evt ) ; 
+  virtual void processEvent( EVENT::LCEvent * evt ) ; 
   
   
-  virtual void check( LCEvent * evt ) ; 
+  virtual void check( EVENT::LCEvent * evt ) ; 
   
   
   /** Called after data processing for clean up.


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a warning about `using namespace` in headers and a few other warnings

ENDRELEASENOTES

These changes are not trivial since repositories like k4MarlinWrapper depending on Marlin will have to be updated too.