### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -6,6 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        include:
+          - release: "sw.hsf.org/key4hep"
+            CXX_STANDARD: 17
+          - release: "sw-nightlies.hsf.org/key4hep"
+            CXX_STANDARD: 20
 
     steps:
     - uses: actions/checkout@v3
@@ -13,14 +19,14 @@ jobs:
     - uses: aidasoft/run-lcg-view@v4
       with:
         container: centos7
-        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
+        view-path: /cvmfs/${{ matrix.release }}
         run: |
           mkdir build
           cd build
           echo "::group::Run CMake"
           cmake -GNinja \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
-            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DCMAKE_INSTALL_PREFIX=../install \
             ..
           echo "::endgroup::" && echo "::group::Build"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        COMPILER: [gcc10, clang11]
-        LCG: [100]
+        COMPILER: [gcc11]
+        LCG: [104]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION

BEGINRELEASENOTES
- Switch to latest clicdp nightlies for CI
- Update Key4hep CI workflows to run on releases and nightlies (including c++20)

ENDRELEASENOTES