### PR TITLE
Allow to empty constant values

### DIFF
--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -873,16 +873,14 @@ namespace marlin{
             }
             
             const std::string key( value.substr( pos+2 , pos2-pos-2 )) ;
-            auto findConstant = constants.find( key ) ;
-            const std::string replacementValue( findConstant != constants.end() ? findConstant->second : "" ) ;
-            
-            if( replacementValue.empty() ) {
-              
+            const auto findConstant = constants.find( key ) ;
+            if (findConstant == constants.end()) {
                 std::stringstream str ;
                 str << "XMLParser::performConstantReplacement : constant \"" << key << "\" not found in available constants !" ;
                 throw ParseException( str.str() ) ;
             }
-            
+            const auto& replacementValue = findConstant->second;
+
             value.replace( pos , (pos2+1-pos) , replacementValue ) ;
             pos2 = pos + replacementValue.size() ; // new end position after replace
             


### PR DESCRIPTION

BEGINRELEASENOTES
- Allow to have empty constant values in steering files and only throw if there really is no constant specified.

ENDRELEASENOTES

This is an alternative to https://github.com/iLCSoft/ILDConfig/pull/136 and I also think this should be the intended behavior.