### PR TITLE
Include GNUInstallDirs to set CMAKE_INSTALL_LIBDIR for MacOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ SET( ${PROJECT_NAME}_VERSION_MAJOR 1 )
 SET( ${PROJECT_NAME}_VERSION_MINOR 19 )
 SET( ${PROJECT_NAME}_VERSION_PATCH 3 )
 
-
+include(GNUInstallDirs)
 
 ### DEPENDENCIES ############################################################
 


### PR DESCRIPTION
The issue is that when building on MacOS, the installation rpath is always set
to `@loader_path/..` which causes the lookup to look in
`<install-prefix>/lib/..` and this doesn't work. The default path is related to
`CMAKE_INSTALL_LIBDIR`, so by including `GNUInstallDirs` `CMAKE_INSTALL_LIBDIR`
gets set to `lib` and then the rpath becomes `@loader_path/../lib` which works.

Before
```
$ otool -l libMarlin.dylib | grep -A2 RPATH
...
          cmd LC_RPATH
      cmdsize 32
         path @loader_path/../ (offset 12)
```

After
```
$ otool -l libgear.dylib | grep -A2 RPATH
...
          cmd LC_RPATH
      cmdsize 32
         path @loader_path/../lib (offset 12)

```

BEGINRELEASENOTES
- Include GNUInstallDirs to set CMAKE_INSTALL_LIBDIR so that the default rpath is
  correct in MacOS and can be used in downstream projects, like in `k4MarlinWrapper`

ENDRELEASENOTES

I tried adding `Key4hepConfig.cmake` but that didn't change anything. I wonder
if passing libraries by full paths instead of cmake targets is the cause since I
haven't seen this issue for other packages.