### PR TITLE
Add LANGUAGES CXX to the top level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8 FATAL_ERROR)
 ########################################################
 
 # project name
-PROJECT( Marlin )
+PROJECT( Marlin LANGUAGES CXX )
 
 
 # project version


### PR DESCRIPTION
BEGINRELEASENOTES
- Add LANGUAGES CXX to the top level CMakeLists.txt to disable checks for a C compiler

ENDRELEASENOTES